### PR TITLE
Add back pk=None to method workflows()

### DIFF
--- a/approval/views.py
+++ b/approval/views.py
@@ -29,7 +29,7 @@ class TemplateViewSet(viewsets.ModelViewSet):
         return TemplateSerializer
 
     @action(detail=True, url_name="workflows")
-    def workflows(self, request):
+    def workflows(self, request, pk=None):
         """sub url template/<id>/workflows"""
 
         template = self.get_object()


### PR DESCRIPTION
It was removed due to lint complaint. Then it caused a test failure.