### PR TITLE
Removed the logging package from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ inflection==0.5.1
 iniconfig==1.1.1
 isort==5.8.0
 lazy-object-proxy==1.6.0
-logging==0.4.9.6
 mccabe==0.6.1
 mypy-extensions==0.4.3
 oauthlib==3.1.1


### PR DESCRIPTION
logging is bundled into python3 and above we dont need this external
library which seems to be for python 2.x