### PR TITLE
Added localization settings

### DIFF
--- a/ansible_catalog/settings/defaults.py
+++ b/ansible_catalog/settings/defaults.py
@@ -17,6 +17,8 @@ from pathlib import Path
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Django gettext files path: locale/<lang-code>/LC_MESSAGES/django.po, django.mo
+LOCALE_PATHS = (os.path.join(BASE_DIR, 'locale'),)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
@@ -49,6 +51,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2307

To run localization use the following command

**python3 manage.py makemessages -i venv -l en**

In the above example the -i venv is used to ignore the virtual env directory 

This would create the files under ansible_catalog/locale/...