### PR TITLE
Enable Django filter backends

### DIFF
--- a/ansible_catalog/settings/defaults.py
+++ b/ansible_catalog/settings/defaults.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.sessions",
     "rest_framework",
+    "django_filters",
     "rest_framework.authtoken",
     "taggit",
     "main",
@@ -91,10 +92,14 @@ DATABASES = {
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 25,
-    'DEFAULT_AUTHENTICATION_CLASSES': [
+    'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
-    ]
+    ),
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
+        'rest_framework.filters.OrderingFilter',
+    ),
 }
 
 # Password validation

--- a/main/approval/views.py
+++ b/main/approval/views.py
@@ -2,8 +2,8 @@
 import logging
 
 from decimal import Decimal
-from rest_framework import viewsets, status, filters
 from rest_framework.decorators import action
+from rest_framework import viewsets, status
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework_extensions.mixins import NestedViewSetMixin
@@ -34,7 +34,6 @@ class TemplateViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
     http_method_names = ["get", "head"]
     permission_classes = (IsAuthenticated,)
     serializer_class = TemplateSerializer
-    filter_backends = (filters.OrderingFilter,)
     ordering_fields = "__all__" # This line is optional, default
     ordering = ("-id",)
 
@@ -45,7 +44,7 @@ class WorkflowViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
     serializer_class = WorkflowSerializer
     http_method_names = ["get", "post", "head", "patch", "delete"]
     permission_classes = (IsAuthenticated,)
-    filter_backends = (filters.OrderingFilter,)
+    filter_fields = ("name", "description","template", "created_at", "updated_at")
     parent_field_name = "template"
     parent_lookup_key = "parent_lookup_template"
     queryset_order_by = "internal_sequence"
@@ -69,8 +68,8 @@ class RequestViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
     serializer_class = RequestSerializer
     http_method_names = ["get", "post"]
     permission_classes = (IsAuthenticated,)
-    filter_backends = (filters.OrderingFilter,)
     ordering = ("-id",)
+    filter_fields = "__all__"
     parent_field_name = "parent"
     parent_lookup_key = "parent_lookup_parent"
 
@@ -103,8 +102,8 @@ class ActionViewSet(QuerySetMixin, viewsets.ModelViewSet):
     serializer_class = ActionSerializer
     http_method_names = ["get", "post"]
     permission_classes = (IsAuthenticated,)
-    filter_backends = (filters.OrderingFilter,)
     ordering = ("-id",)
+    filter_fields = "__all__"
     parent_field_name = "request"
     parent_lookup_key = "parent_lookup_request"
 

--- a/main/catalog/models.py
+++ b/main/catalog/models.py
@@ -30,7 +30,6 @@ class Portfolio(BaseModel):
                 fields=["name", "tenant"],
             ),
         ]
-        ordering = ["-created_at"]
 
     def __str__(self):
         return self.name
@@ -71,7 +70,6 @@ class PortfolioItem(BaseModel):
                 fields=["name", "tenant", "portfolio"],
             ),
         ]
-        ordering = ["-created_at"]
 
     def __str__(self):
         return self.name
@@ -100,7 +98,6 @@ class Order(UserOwnedModel):
     completed_at = models.DateTimeField(editable=False, null=True)
 
     class Meta:
-        ordering = ["-created_at"]
         indexes = [
             models.Index(fields=['tenant', 'user'])
         ]
@@ -159,7 +156,6 @@ class OrderItem(UserOwnedModel):
                 fields=["name", "tenant", "order", "portfolio_item"],
             ),
         ]
-        ordering = ["-created_at"]
 
     def __str__(self):
         return self.name

--- a/main/catalog/serializers.py
+++ b/main/catalog/serializers.py
@@ -27,7 +27,6 @@ class PortfolioSerializer(serializers.ModelSerializer):
     class Meta:
         model = Portfolio
         fields = ("id", "name", "description", "created_at", "updated_at")
-        ordering = ["-created_at"]
         read_only_fields = ("created_at", "updated_at")
 
     def create(self, validated_data):
@@ -40,7 +39,6 @@ class PortfolioItemSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PortfolioItem
-        ordering = ["-created_at"]
         fields = (
             "id",
             "name",
@@ -72,7 +70,6 @@ class OrderSerializer(serializers.ModelSerializer):
             "updated_at",
             "completed_at"
         )
-        ordering = ["-created_at"]
         read_only_fields = ("created_at", "updated_at")
 
     def create(self, validated_data):
@@ -103,7 +100,6 @@ class OrderItemSerializer(serializers.ModelSerializer):
             "updated_at",
             "completed_at"
         )
-        ordering = ["-created_at"]
         read_only_fields = ("created_at", "updated_at")
 
     def create(self, validated_data):

--- a/main/catalog/views.py
+++ b/main/catalog/views.py
@@ -29,18 +29,22 @@ logger = logging.getLogger("catalog")
 class TenantViewSet(viewsets.ReadOnlyModelViewSet):
     """API endpoint for listing and creating tenants."""
 
-    queryset = Tenant.objects.all().order_by("id")
+    queryset = Tenant.objects.all()
     serializer_class = TenantSerializer
     permission_classes = (IsAuthenticated,)
+    ordering = ("id",)
+    filter_fields = "__all__"
 
 
 class PortfolioViewSet(TagMixin, NestedViewSetMixin, viewsets.ModelViewSet):
     """API endpoint for listing and creating portfolios."""
 
-    queryset = Portfolio.objects.all().order_by("created_at")
+    queryset = Portfolio.objects.all()
     serializer_class = PortfolioSerializer
     http_method_names = ["get", "post", "head", "patch", "delete"]
     permission_classes = (IsAuthenticated,)
+    ordering = ("-id",)
+    filter_fields = ("name", "description", "created_at", "updated_at")
 
 
 class PortfolioItemViewSet(TagMixin, NestedViewSetMixin, viewsets.ModelViewSet):
@@ -50,15 +54,32 @@ class PortfolioItemViewSet(TagMixin, NestedViewSetMixin, viewsets.ModelViewSet):
     serializer_class = PortfolioItemSerializer
     http_method_names = ["get", "post", "head", "patch", "delete"]
     permission_classes = (IsAuthenticated,)
+    ordering = ("-id",)
+    filter_fields = (
+        "name", 
+        "description",
+        "service_offering_ref",
+        "portfolio",
+        "created_at",
+        "updated_at"
+    )
 
 
 class OrderViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     """API endpoint for listing and creating orders."""
 
-    queryset = Order.objects.all().order_by("created_at")
+    queryset = Order.objects.all()
     serializer_class = OrderSerializer
     http_method_names = ["get", "post", "head", "delete"]
     permission_classes = (IsAuthenticated,)
+    ordering = ("-id",)
+    filter_fields = (
+        "state",
+        "order_request_sent_at",
+        "created_at",
+        "updated_at",
+        "completed_at"
+    )
 
     # TODO:
     @action(methods=["post"], detail=True)
@@ -76,7 +97,20 @@ class OrderViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
 class OrderItemViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     """API endpoint for listing and creating order items."""
 
-    queryset = OrderItem.objects.all().order_by("created_at")
+    queryset = OrderItem.objects.all()
     serializer_class = OrderItemSerializer
     http_method_names = ["get", "post", "head", "delete"]
     permission_classes = (IsAuthenticated,)
+    ordering = ("-id",)
+    filter_fields = (
+        "name",
+        "count",
+        "state",
+        "portfolio_item",
+        "order",
+        "external_url",
+        "order_request_sent_at",
+        "created_at",
+        "updated_at",
+        "completed_at"
+    )

--- a/main/inventory/serializers.py
+++ b/main/inventory/serializers.py
@@ -33,7 +33,6 @@ class ServiceInventorySerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         )
-        ordering = ["-created_at"]
         read_only_fields = ("created_at", "updated_at")
 
 
@@ -51,7 +50,6 @@ class ServiceOfferingSerializer(serializers.ModelSerializer):
             "extra",
             "service_inventory",
         )
-        ordering = ["-created_at"]
         read_only_fields = ("created_at", "updated_at")
 
 
@@ -67,7 +65,6 @@ class ServiceOfferingNodeSerializer(serializers.ModelSerializer):
             "root_service_offering",
             "extra",
         )
-        ordering = ["-created_at"]
         read_only_fields = ("created_at", "updated_at")
 
 
@@ -84,5 +81,4 @@ class ServicePlanSerializer(serializers.ModelSerializer):
             "update_json_schema",
             "service_offering",
         )
-        ordering = ["-created_at"]
         read_only_fields = ("created_at", "updated_at")

--- a/main/inventory/views.py
+++ b/main/inventory/views.py
@@ -33,9 +33,11 @@ logger = logging.getLogger("inventory")
 class SourceViewSet(NestedViewSetMixin, ModelViewSet):
     """API endpoint for listing and updating sources."""
 
-    queryset = Source.objects.all().order_by("created_at")
+    queryset = Source.objects.all()
     serializer_class = SourceSerializer
     permission_classes = (IsAuthenticated,)
+    ordering = ("-id",)
+    filter_fields = ("name",)
 
     # Enable PATCH for refresh API
     http_method_names = ["get", "patch", "head"]
@@ -51,18 +53,28 @@ class SourceViewSet(NestedViewSetMixin, ModelViewSet):
 class ServicePlanViewSet(NestedViewSetMixin, ModelViewSet):
     """API endpoint for listing and retrieving service plans."""
 
-    queryset = ServicePlan.objects.all().order_by("created_at")
+    queryset = ServicePlan.objects.all()
     serializer_class = ServicePlanSerializer
     permission_classes = (IsAuthenticated,)
+    ordering = ("-id",)
+    filter_fields = ("name", "service_offering",)
 
     http_method_names = ["get", "head"]
 
 class ServiceOfferingViewSet(NestedViewSetMixin, ModelViewSet):
     """API endpoint for listing and retrieving service offerings."""
 
-    queryset = ServiceOffering.objects.all().order_by("created_at")
+    queryset = ServiceOffering.objects.all()
     serializer_class = ServiceOfferingSerializer
     permission_classes = (IsAuthenticated,)
+    ordering = ("-id",)
+    filter_fields = (
+        "name",
+        "description",
+        "survey_enabled",
+        "kind",
+        "service_inventory",
+    )
 
     http_method_names = ["get", "head"]
 
@@ -79,9 +91,18 @@ class ServiceOfferingViewSet(NestedViewSetMixin, ModelViewSet):
 class ServiceInventoryViewSet(TagMixin, NestedViewSetMixin, ModelViewSet):
     """API endpoint for listing and creating service inventories."""
 
-    queryset = ServiceInventory.objects.all().order_by("created_at")
+    queryset = ServiceInventory.objects.all()
     serializer_class = ServiceInventorySerializer
     permission_classes = (IsAuthenticated,)
+    ordering = ("-id",)
+    filter_fields = (
+        "description",
+        "source_ref",
+        "source_created_at",
+        "source_updated_at",
+        "created_at",
+        "updated_at",
+    )
 
     # For tagging purpose, enable POST action here
     http_method_names = ["get", "post", "head"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ cwcwidth==0.1.4
 defusedxml==0.7.1
 Django==3.2.5
 django-rq==2.4.1
+django-filter==2.4.0
 django-split-settings==1.0.1
 django-taggit==1.5.1
 djangorestframework==3.12.4


### PR DESCRIPTION
set global `DEFAULT_FILTER_BACKENDS` to `DjangoFilterBackend` and `OrderingFilter`.
The query parameter for filter is like `/?fieldname=fieldvalue`
The query parameter for ordering is like `/?ordering=created_at` or `/?ordering=-created_at`

At each viewset we must define `filter_fields` to include a list of allowed fields. It is optional to define `ordering_fields`, by default all fields are sortable. Set `ordering` to default ordering fields.

Remove other ordering parameters in models and serializers. 
 