### PR TITLE
Fix special str function for Order

### DIFF
--- a/main/catalog/models.py
+++ b/main/catalog/models.py
@@ -106,7 +106,7 @@ class Order(UserOwnedModel):
         ]
 
     def __str__(self):
-        return self.id
+        return str(self.id)
 
 
 class OrderItem(UserOwnedModel):


### PR DESCRIPTION
Fix the TypeError at /api/v1/order_items/
```__str__ returned non-string (type int)```