### PR TITLE
Add an endpoint to include sub_requests and actions in request

### DIFF
--- a/common/queryset_mixin.py
+++ b/common/queryset_mixin.py
@@ -13,7 +13,8 @@ class QuerySetMixin():
         parent_lookup_key = getattr(self, "parent_lookup_key", None)
         parent_field_name = getattr(self, "parent_field_name", None)
         queryset_order_by = getattr(self, "queryset_order_by", None)
-        queryset = self.serializer_class.Meta.model.objects.filter(tenant=Tenant.current())
+        serializer_class = self.get_serializer_class() or self.serializer_class
+        queryset = serializer_class.Meta.model.objects.filter(tenant=Tenant.current())
         if parent_lookup_key in self.kwargs:
             queryset = queryset.filter(**{parent_field_name: self.kwargs[parent_lookup_key]})
         if queryset_order_by is not None:

--- a/main/approval/models.py
+++ b/main/approval/models.py
@@ -60,9 +60,11 @@ class Workflow(BaseModel):
     def __str__(self):
         return self.name
 
+
 class RequestContext(models.Model):
     content = models.JSONField()
     context = models.JSONField()
+
 
 class Request(BaseModel):
     """Request model"""
@@ -96,7 +98,7 @@ class Request(BaseModel):
     number_of_children = models.SmallIntegerField(editable=False, default=0)
     number_of_finished_children = models.SmallIntegerField(editable=False, default=0)
     workflow = models.ForeignKey(Workflow, null=True, on_delete=models.SET_NULL)
-    parent = models.ForeignKey('self', on_delete=models.CASCADE, null=True)
+    parent = models.ForeignKey('self', on_delete=models.CASCADE, null=True, related_name="sub_requests")
     request_context = models.ForeignKey(RequestContext, null=True, on_delete=models.SET_NULL)
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=True)
 
@@ -109,7 +111,6 @@ class Request(BaseModel):
     def owner(self):
         """virtual column owner"""
         return f"{self.user.username}"
-
 
     def __str__(self):
         return self.name
@@ -131,7 +132,7 @@ class Action(BaseModel):
     processed_by = models.CharField(max_length=128, editable=False)
     operation = models.CharField(max_length=10, choices=Operation.choices, default=Operation.Memo)
     comments = models.TextField(blank=True)
-    request = models.ForeignKey(Request, on_delete=models.CASCADE)
+    request = models.ForeignKey(Request, on_delete=models.CASCADE, related_name="actions")
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=True)
 
     @property

--- a/main/approval/serializers.py
+++ b/main/approval/serializers.py
@@ -35,29 +35,31 @@ class WorkflowSerializer(serializers.ModelSerializer):
         )
         read_only_fields = ("created_at", "updated_at", "template")
 
+class RequestFields:
+    FIELDS = (
+        "id",
+        "requester_name",
+        "owner",
+        "name",
+        "description",
+        "workflow",
+        "state",
+        "decision",
+        "reason",
+        "number_of_children",
+        "number_of_finished_children",
+        "created_at",
+        "notified_at",
+        "finished_at",
+    )
+
 
 class RequestSerializer(serializers.ModelSerializer):
     """Serializer for Request"""
 
     class Meta:
         model = Request
-        fields = (
-            "id",
-            "requester_name",
-            "owner",
-            "name",
-            "description",
-            "workflow",
-            "state",
-            "decision",
-            "reason",
-            "parent",
-            "number_of_children",
-            "number_of_finished_children",
-            "created_at",
-            "notified_at",
-            "finished_at",
-        )
+        fields = (*RequestFields.FIELDS, "parent",)
         read_only_fields = ("__all__", "requester_name", "owner",)
 
 
@@ -90,3 +92,15 @@ class ActionSerializer(serializers.ModelSerializer):
             "comments",
         )
         read_only_fields = ("created_at", "request")
+
+
+class RequestCompleteSerializer(serializers.ModelSerializer):
+    """Serializer for Request with nested actions and children"""
+
+    actions = ActionSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Request
+        fields = (*RequestFields.FIELDS, "actions", "sub_requests",)
+
+RequestCompleteSerializer._declared_fields['sub_requests'] = RequestCompleteSerializer(many=True)

--- a/main/approval/tests/functional/test_requst_end_points.py
+++ b/main/approval/tests/functional/test_requst_end_points.py
@@ -183,3 +183,22 @@ def test_request_action_not_supported_methods(api_request):
 
     response = api_request("delete", url)
     assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_request_full_action(api_request):
+    parent = RequestFactory()
+    child = RequestFactory(parent=parent)
+    parent_action = ActionFactory(request=parent)
+    child_action = ActionFactory(request=child)
+    url = reverse("request-full", args=(parent.id,))
+
+    response = api_request("get", url)
+    content = json.loads(response.content)
+    assert response.status_code == 200
+    assert content["sub_requests"][0]["name"] == child.name
+    assert content["sub_requests"][0]["id"] == child.id
+    assert content["actions"][0]["operation"] == parent_action.operation
+    assert content["actions"][0]["id"] == parent_action.id
+    assert content["sub_requests"][0]["actions"][0]["operation"] == child_action.operation
+    assert content["sub_requests"][0]["actions"][0]["id"] == child_action.id

--- a/main/approval/views.py
+++ b/main/approval/views.py
@@ -3,6 +3,7 @@ import logging
 
 from decimal import Decimal
 from rest_framework import viewsets, status, filters
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework_extensions.mixins import NestedViewSetMixin
@@ -20,6 +21,7 @@ from main.approval.serializers import (
     WorkflowSerializer,
     RequestSerializer,
     RequestInSerializer,
+    RequestCompleteSerializer,
     ActionSerializer,
 )
 from common.queryset_mixin import QuerySetMixin
@@ -60,6 +62,7 @@ class WorkflowViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
             tenant=Tenant.current()
         )
 
+
 class RequestViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
     """API endpoint for listing and creating requests"""
 
@@ -85,6 +88,13 @@ class RequestViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
         except Exception as error:
             raise ValidationError({"detail": error}) from error
         return Response(output_serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(methods=["get"], detail=True)
+    def full(self, request, pk):
+        """Details of a request with its sub_requests and actions"""
+        instance = self.get_object()
+        serializer = RequestCompleteSerializer(instance)
+        return Response(serializer.data)
 
 
 class ActionViewSet(QuerySetMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
The new endpoint is replacement of old graphql.
`GET /api/v1/requests/1/full/`
```
{
    "id": 1,
    "requester_name": "Fred Copper",
    "owner": "fred",
    "name": "request1",
    "description": "r1",
    "workflow": null,
    "state": "Pending",
    "decision": "Undecided",
    "reason": "",
    "number_of_children": 1,
    "number_of_finished_children": 0,
    "created_at": "2021-07-23T15:53:49.919196Z",
    "notified_at": null,
    "finished_at": null,
    "actions": [
        {
            "id": 1,
            "created_at": "2021-07-23T15:56:29.506893Z",
            "request": 1,
            "processed_by": "Fred Copper",
            "operation": "Memo",
            "comments": "hello"
        }
    ],
    "sub_requests": [
        {
            "id": 2,
            "name": "c1",
            "description": "",
            "workflow": null,
            "state": "Pending",
            "decision": "Undecided",
            "reason": "",
            "number_of_children": 0,
            "number_of_finished_children": 0,
            "created_at": "2021-07-28T21:01:06.692276Z",
            "notified_at": null,
            "finished_at": null,
            "actions": []
        }
    ]
}
```