### PR TITLE
Add tox -epy38 entry point

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,9 +45,6 @@ pylint==2.8.3
 pylint-django==2.4.4
 pylint-plugin-utils==0.6
 pyparsing==2.4.7
-pytest==6.2.4
-pytest-django==4.4.0
-pytest-factoryboy==2.1.0
 python-dateutil==2.8.1
 pytz==2021.1
 pyxdg==0.27

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,4 @@
 black
+pytest
+pytest-django
+pytest-factoryboy

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = linters
+envlist = linters,py38
 
 [testenv]
 basepython = python3
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+commands = pytest {posargs}
 
 [testenv:black]
 commands =


### PR DESCRIPTION
Allow a user to run pytest jobs via tox.

This also starts to move testing dependencies into test-requirements.txt
to make packaging easier.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>