### PR TITLE
Initial commit for container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+ARG PYTHON_BASE_IMAGE=quay.io/ansible/python-base:latest
+ARG PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:latest
+ARG ZUUL_SIBLINGS=""
+
+FROM $PYTHON_BUILDER_IMAGE as builder
+# =============================================================================
+ARG ZUUL_SIBLINGS
+
+COPY . /tmp/src
+# NOTE(pabelanger): For downstream builds, we compile everything from source
+# over using existing wheels. Do this upstream too so we can better catch
+# issues.
+ENV PIP_OPTS=--no-build-isolation
+RUN assemble
+
+FROM $PYTHON_BASE_IMAGE
+# =============================================================================
+
+COPY --from=builder /output/ /output
+RUN /output/install-from-bindep \
+  && rm -rf /output

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,5 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see https://docs.openstack.org/infra/bindep/ for additional information.
+
+python38-psycopg2 [platform:centos-8]
+python38-requests [platform:centos-8]


### PR DESCRIPTION
We eventually want to support ansible-catalog via a container, this is
the first step to do that. We can leverage the existing python-builder /
python-base images to create the container since this is a python
project.

Future improvements will be do some functional testing using the
container to confirm everything is properly configured. So far, this
just builds and installs the project inside the container.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>