### PR TITLE
Missing python-dateutil in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ django-taggit
 djangorestframework
 drf-extensions
 psycopg2
+python-dateutil
 requests


### PR DESCRIPTION
In the refactoring of requirements.txt we dropped this package
When running migrations we detected this missing file