### PR TITLE
Enable drf-spectacular to generate openapi schema

### DIFF
--- a/ansible_catalog/settings/defaults.py
+++ b/ansible_catalog/settings/defaults.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     "taggit",
     "main",
     "django_rq",
+    "drf_spectacular",
 ]
 
 MIDDLEWARE = [
@@ -102,6 +103,7 @@ REST_FRAMEWORK = {
         "django_filters.rest_framework.DjangoFilterBackend",
         "rest_framework.filters.OrderingFilter",
     ),
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
 # Password validation
@@ -268,4 +270,32 @@ RQ_QUEUES = {
         "DB": 0,
         "DEFAULT_TIMEOUT": 360,
     },
+}
+
+# Auto generation of openapi spec using Spectacular
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Catalog API",
+    "DESCRIPTION": "A set of APIs to create and manage Ansible catalogs and order from them.",
+    "VERSION": "0.1.0",
+    "CONTACT": {
+        "email": "support@redhat.com",
+    },
+    "LICENSE": {
+        "name": "Apache 2.0",
+        "url": "http://www.apache.org/licenses/LICENSE-2.0.html",
+    },
+    "SERVERS": [
+        {
+            "url": "http://localhost:{port}/{basePath}",
+            "description": "Development Server",
+            "variables": {
+                "port": {
+                    "default": "8000",
+                },
+                "basePath": {
+                    "default": "/api/v1",
+                },
+            },
+        },
+    ],
 }

--- a/main/approval/models.py
+++ b/main/approval/models.py
@@ -2,6 +2,7 @@
 from django.db import models
 from django.db.models.functions import Length
 from django.contrib.auth.models import User
+from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 from main.models import BaseModel
 
@@ -126,11 +127,13 @@ class Request(BaseModel):
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=True)
 
     @property
+    @extend_schema_field(OpenApiTypes.STR)
     def requester_name(self):
         """virtual column requester_name"""
         return f"{self.user.first_name} {self.user.last_name}"
 
     @property
+    @extend_schema_field(OpenApiTypes.STR)
     def owner(self):
         """virtual column owner"""
         return f"{self.user.username}"
@@ -152,7 +155,6 @@ class Action(BaseModel):
         CANCEL = "Cancel"
         ERROR = "Error"
 
-    processed_by = models.CharField(max_length=128, editable=False)
     operation = models.CharField(
         max_length=10, choices=Operation.choices, default=Operation.Memo
     )
@@ -163,6 +165,7 @@ class Action(BaseModel):
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=True)
 
     @property
+    @extend_schema_field(OpenApiTypes.STR)
     def processed_by(self):
         """virtual column processed_by"""
         return f"{self.user.first_name} {self.user.last_name}"

--- a/main/catalog/serializers.py
+++ b/main/catalog/serializers.py
@@ -1,5 +1,6 @@
 """ Serializers for Catalog Model."""
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 from main.models import Tenant, Image
 from main.catalog.models import (
@@ -46,6 +47,7 @@ class PortfolioSerializer(serializers.ModelSerializer):
             tenant=Tenant.current(), **validated_data
         )
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_icon_url(self, obj):
         request = self.context.get("request")
         return (
@@ -81,6 +83,7 @@ class PortfolioItemSerializer(serializers.ModelSerializer):
             tenant=Tenant.current(), **validated_data
         )
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_icon_url(self, obj):
         request = self.context.get("request")
         return (

--- a/main/migrations/0004_auto_20210818_1530.py
+++ b/main/migrations/0004_auto_20210818_1530.py
@@ -7,44 +7,123 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('main', '0003_auto_20210805_1949'),
+        ("main", "0003_auto_20210805_1949"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='ProgressMessage',
+            name="ProgressMessage",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('updated_at', models.DateTimeField(auto_now=True)),
-                ('level', models.CharField(choices=[('Info', 'Info'), ('Error', 'Error'), ('Warning', 'Warning'), ('Debug', 'Debug')], default='Info', editable=False, max_length=10)),
-                ('received_at', models.DateTimeField(auto_now_add=True)),
-                ('message', models.TextField(blank=True, default='')),
-                ('messageable_type', models.CharField(max_length=64, null=True)),
-                ('messageable_id', models.IntegerField(editable=False, null=True)),
-                ('tenant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.tenant')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "level",
+                    models.CharField(
+                        choices=[
+                            ("Info", "Info"),
+                            ("Error", "Error"),
+                            ("Warning", "Warning"),
+                            ("Debug", "Debug"),
+                        ],
+                        default="Info",
+                        editable=False,
+                        max_length=10,
+                    ),
+                ),
+                ("received_at", models.DateTimeField(auto_now_add=True)),
+                ("message", models.TextField(blank=True, default="")),
+                (
+                    "messageable_type",
+                    models.CharField(max_length=64, null=True),
+                ),
+                (
+                    "messageable_id",
+                    models.IntegerField(editable=False, null=True),
+                ),
+                (
+                    "tenant",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="main.tenant",
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
-            name='ApprovalRequest',
+            name="ApprovalRequest",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('updated_at', models.DateTimeField(auto_now=True)),
-                ('approval_request_ref', models.CharField(default='', max_length=64)),
-                ('reason', models.TextField(blank=True, default='')),
-                ('request_completed_at', models.DateTimeField(editable=False, null=True)),
-                ('state', models.CharField(choices=[('Undecided', 'Undecided'), ('Approved', 'Approved'), ('Canceled', 'Canceled'), ('Denied', 'Denied'), ('Failed', 'Failed')], default='Undecided', editable=False, max_length=10)),
-                ('order', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to='main.order')),
-                ('tenant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.tenant')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "approval_request_ref",
+                    models.CharField(default="", max_length=64),
+                ),
+                ("reason", models.TextField(blank=True, default="")),
+                (
+                    "request_completed_at",
+                    models.DateTimeField(editable=False, null=True),
+                ),
+                (
+                    "state",
+                    models.CharField(
+                        choices=[
+                            ("Undecided", "Undecided"),
+                            ("Approved", "Approved"),
+                            ("Canceled", "Canceled"),
+                            ("Denied", "Denied"),
+                            ("Failed", "Failed"),
+                        ],
+                        default="Undecided",
+                        editable=False,
+                        max_length=10,
+                    ),
+                ),
+                (
+                    "order",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="main.order",
+                    ),
+                ),
+                (
+                    "tenant",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="main.tenant",
+                    ),
+                ),
             ],
         ),
         migrations.AddIndex(
-            model_name='progressmessage',
-            index=models.Index(fields=['tenant', 'messageable_id', 'messageable_type'], name='main_progre_tenant__e6daa2_idx'),
+            model_name="progressmessage",
+            index=models.Index(
+                fields=["tenant", "messageable_id", "messageable_type"],
+                name="main_progre_tenant__e6daa2_idx",
+            ),
         ),
         migrations.AddIndex(
-            model_name='approvalrequest',
-            index=models.Index(fields=['tenant', 'order'], name='main_approv_tenant__9d790f_idx'),
+            model_name="approvalrequest",
+            index=models.Index(
+                fields=["tenant", "order"],
+                name="main_approv_tenant__9d790f_idx",
+            ),
         ),
     ]

--- a/main/models.py
+++ b/main/models.py
@@ -2,6 +2,7 @@
 from django.db import models
 from django.db.utils import OperationalError
 from django.contrib.auth.models import User
+from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 
 class Tenant(models.Model):
@@ -65,8 +66,9 @@ class UserOwnedModel(BaseModel):
         abstract = True
 
     @property
+    @extend_schema_field(OpenApiTypes.STR)
     def owner(self):
-        "Use for serializer_class"
+        """Use for serializer_class"""
         return self.user.username
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ django-split-settings
 django-taggit
 djangorestframework
 drf-extensions
+drf-spectacular
 Pillow
 psycopg2
 python-dateutil


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2336
https://issues.redhat.com/browse/SSP-2337

drf-spectacular is able to resolve the uniqueness of operation id used by nesting urls, but some warnings, all related to parent_lookup id in the nesting urls, still exist. We will need to do more researches.