### PR TITLE
Suppress unwanted endpoints

### DIFF
--- a/ansible_catalog/urls.py
+++ b/ansible_catalog/urls.py
@@ -19,15 +19,38 @@ from rest_framework import routers
 from django.conf import settings
 from django.conf.urls.static import static
 
-from main.catalog.urls import router as catalog_router
-from main.approval.urls import router as approval_router
-from main.inventory.urls import router as inventory_router
+from main.catalog.urls import (
+    router as catalog_router,
+    urls_views as catalog_views,
+)
+from main.approval.urls import (
+    router as approval_router,
+    urls_views as approval_views,
+)
+from main.inventory.urls import (
+    router as inventory_router,
+    urls_views as inventory_views,
+)
+
+
+def __filter_by_view(pattern):
+    name = pattern.name
+    if name in urls_views:
+        if urls_views[name] == None:
+            return False
+        pattern.callback = urls_views[name]
+    return True
+
 
 router = routers.DefaultRouter()
 router.registry.extend(catalog_router.registry)
 router.registry.extend(approval_router.registry)
 router.registry.extend(inventory_router.registry)
 
+urls_patterns = router.urls
+urls_views = {**catalog_views, **approval_views, **inventory_views}
+urls_patterns = [p for p in urls_patterns if __filter_by_view(p)]
+
 urlpatterns = [
-    path(r"api/v1/", include(router.urls)),
+    path(r"api/v1/", include(urls_patterns)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/main/approval/tests/functional/test_requst_end_points.py
+++ b/main/approval/tests/functional/test_requst_end_points.py
@@ -50,18 +50,6 @@ def test_request_child_list(api_request):
 
 
 @pytest.mark.django_db
-def test_request_child_detail(api_request):
-    parent = RequestFactory()
-    child = RequestFactory(parent=parent)
-    url = reverse("request-request-detail", args=(parent.id, child.id))
-    response = api_request("get", url)
-
-    assert response.status_code == 200
-    content = json.loads(response.content)
-    assert content["id"] == child.id
-
-
-@pytest.mark.django_db
 def test_request_action_list(api_request):
     request = RequestFactory()
     ActionFactory(request=request, operation="Start")
@@ -73,18 +61,6 @@ def test_request_action_list(api_request):
     content = json.loads(response.content)
 
     assert content["count"] == 2
-
-
-@pytest.mark.django_db
-def test_request_action_detail(api_request):
-    request = RequestFactory()
-    action = ActionFactory(request=request)
-    url = reverse("request-action-detail", args=(request.id, action.id))
-    response = api_request("get", url)
-
-    assert response.status_code == 200
-    content = json.loads(response.content)
-    assert content["id"] == action.id
 
 
 @pytest.mark.django_db
@@ -149,44 +125,6 @@ def test_request_request_not_create(api_request):
         },
     )
 
-    assert response.status_code == 400
-
-
-@pytest.mark.django_db
-def test_request_request_not_supported_methods(api_request):
-    parent = RequestFactory()
-    child = RequestFactory(parent=parent)
-    url = reverse(
-        "request-request-detail",
-        args=(
-            parent.id,
-            child.id,
-        ),
-    )
-
-    response = api_request("put", url, {"name": "update"})
-    assert response.status_code == 405
-
-    response = api_request("patch", url, {"name": "update"})
-    assert response.status_code == 405
-
-    response = api_request("delete", url)
-    assert response.status_code == 405
-
-
-@pytest.mark.django_db
-def test_request_action_not_supported_methods(api_request):
-    request = RequestFactory()
-    action = ActionFactory(request=request)
-    url = reverse("request-action-detail", args=(request.id, action.id))
-
-    response = api_request("put", url, {"operation": "skip"})
-    assert response.status_code == 405
-
-    response = api_request("patch", url, {"operation": "skip"})
-    assert response.status_code == 405
-
-    response = api_request("delete", url)
     assert response.status_code == 405
 
 

--- a/main/approval/urls.py
+++ b/main/approval/urls.py
@@ -1,7 +1,6 @@
 """URLs for approval"""
 from rest_framework.routers import DefaultRouter
 from rest_framework_extensions.routers import NestedRouterMixin
-from django.urls import include, path
 
 from main.approval.views import (
     TemplateViewSet,
@@ -9,6 +8,8 @@ from main.approval.views import (
     RequestViewSet,
     ActionViewSet,
 )
+
+urls_views = {}
 
 
 class NestedDefaultRouter(NestedRouterMixin, DefaultRouter):
@@ -24,8 +25,12 @@ templates.register(
     basename="template-workflow",
     parents_query_lookups=["template"],
 )
+urls_views["template-workflow-detail"] = None  # disable
 
 router.register("workflows", WorkflowViewSet, basename="workflow")
+urls_views["workflow-list"] = WorkflowViewSet.as_view(
+    {"get": "list"}
+)  # list only
 
 requests = router.register("requests", RequestViewSet, basename="request")
 requests.register(
@@ -40,9 +45,12 @@ requests.register(
     basename="request-request",
     parents_query_lookups=["parent"],
 )
+urls_views["request-action-detail"] = None  # disable
+urls_views["request-request-detail"] = None
+urls_views["request-request-full"] = None
+urls_views["request-request-list"] = RequestViewSet.as_view(
+    {"get": "list"}
+)  # list only
 
 router.register("actions", ActionViewSet, basename="action")
-
-urlpatterns = [
-    path("", include((router.urls, "approval"))),
-]
+urls_views["action-list"] = None

--- a/main/catalog/tests/functional/test_order_end_points.py
+++ b/main/catalog/tests/functional/test_order_end_points.py
@@ -4,8 +4,11 @@ import pytest
 from django.urls import reverse
 
 from main.tests.factories import TenantFactory
-from main.catalog.tests.factories import OrderFactory
-from main.catalog.tests.factories import OrderItemFactory
+from main.catalog.tests.factories import (
+    OrderFactory,
+    OrderItemFactory,
+    PortfolioItemFactory,
+)
 
 
 @pytest.mark.django_db
@@ -95,3 +98,19 @@ def test_order_order_items_get(api_request):
 
     assert content["count"] == 1
     assert content["results"][0]["id"] == order_item.id
+
+
+@pytest.mark.django_db
+def test_order_order_item_post(api_request):
+    """Create a new order item from an order"""
+    order = OrderFactory()
+    portfolio_item = PortfolioItemFactory()
+    data = {
+        "order": order.id,  # TODO: remove order from data
+        "portfolio_item": portfolio_item.id,
+        "name": "abcdef",
+    }
+    response = api_request(
+        "post", reverse("order-orderitem-list", args=(order.id,)), data
+    )
+    assert response.status_code == 201

--- a/main/catalog/tests/functional/test_order_item_end_points.py
+++ b/main/catalog/tests/functional/test_order_item_end_points.py
@@ -10,18 +10,6 @@ from main.catalog.tests.factories import (
 
 
 @pytest.mark.django_db
-def test_order_item_list(api_request):
-    """Get list of Order Items"""
-    OrderItemFactory()
-    response = api_request("get", reverse("orderitem-list"))
-
-    assert response.status_code == 200
-    content = json.loads(response.content)
-
-    assert content["count"] == 1
-
-
-@pytest.mark.django_db
 def test_order_item_retrieve(api_request):
     """Retrieve a single order item by id"""
     order_item = OrderItemFactory()
@@ -44,20 +32,6 @@ def test_order_item_delete(api_request):
     )
 
     assert response.status_code == 204
-
-
-@pytest.mark.django_db
-def test_order_item_post(api_request):
-    """Create a new order item for a order"""
-    order = OrderFactory()
-    portfolio_item = PortfolioItemFactory()
-    data = {
-        "order": order.id,
-        "portfolio_item": portfolio_item.id,
-        "name": "abcdef",
-    }
-    response = api_request("post", reverse("orderitem-list"), data)
-    assert response.status_code == 201
 
 
 @pytest.mark.django_db

--- a/main/catalog/urls.py
+++ b/main/catalog/urls.py
@@ -1,4 +1,3 @@
-from django.urls import include, path
 from rest_framework import routers
 
 from rest_framework_extensions.routers import NestedRouterMixin
@@ -12,6 +11,8 @@ from main.catalog.views import (
     ApprovalRequestViewSet,
     ProgressMessageViewSet,
 )
+
+urls_views = {}
 
 
 class NestedDefaultRouter(NestedRouterMixin, routers.DefaultRouter):
@@ -28,7 +29,15 @@ portfolios.register(
     basename="portfolio-portfolioitem",
     parents_query_lookups=["portfolio"],
 )
-portfolio_items = router.register(r"portfolio_items", PortfolioItemViewSet)
+router.register(r"portfolio_items", PortfolioItemViewSet)
+urls_views["portfolio-portfolioitem-detail"] = None  # disable
+urls_views["portfolio-portfolioitem-icon"] = None
+urls_views["portfolio-portfolioitem-tag"] = None
+urls_views["portfolio-portfolioitem-tags"] = None
+urls_views["portfolio-portfolioitem-untag"] = None
+urls_views["portfolio-portfolioitem-list"] = PortfolioItemViewSet.as_view(
+    {"get": "list"}
+)  # read only
 
 orders = router.register(r"orders", OrderViewSet)
 orders.register(
@@ -49,6 +58,11 @@ orders.register(
     basename="order-progressmessage",
     parents_query_lookups=["messageable_id"],
 )
+urls_views["order-orderitem-detail"] = OrderItemViewSet.as_view(
+    {"get": "retrieve"}
+)  # read only
+urls_views["order-approvalrequest-detail"] = None
+urls_views["order-progressmessage-detail"] = None
 
 order_items = router.register(r"order_items", OrderItemViewSet)
 order_items.register(
@@ -57,7 +71,5 @@ order_items.register(
     basename="orderitem-progressmessage",
     parents_query_lookups=["messageable_id"],
 )
-
-urlpatterns = [
-    path("", include((router.urls, "catalog"))),
-]
+urls_views["orderitem-list"] = None
+urls_views["orderitem-progressmessage-detail"] = None

--- a/main/inventory/urls.py
+++ b/main/inventory/urls.py
@@ -1,5 +1,4 @@
 """URLs for Inventory"""
-from django.urls import include, path
 from rest_framework import routers
 
 from rest_framework_extensions.routers import NestedRouterMixin
@@ -9,6 +8,8 @@ from main.inventory.views import (
     ServicePlanViewSet,
     ServiceOfferingViewSet,
 )
+
+urls_views = {}
 
 
 class NestedDefaultRouter(NestedRouterMixin, routers.DefaultRouter):
@@ -23,6 +24,10 @@ sources.register(
     basename="source-service_inventory",
     parents_query_lookups=["source"],
 )
+urls_views["source-service_inventory-detail"] = None  # disable
+urls_views["source-service_inventory-tag"] = None
+urls_views["source-service_inventory-tags"] = None
+urls_views["source-service_inventory-untag"] = None
 
 sources.register(
     r"service_plans",
@@ -30,6 +35,7 @@ sources.register(
     basename="source-service_plan",
     parents_query_lookups=["source"],
 )
+urls_views["source-service_plan-detail"] = None
 
 sources.register(
     r"service_offerings",
@@ -37,6 +43,9 @@ sources.register(
     basename="source-service_offering",
     parents_query_lookups=["source"],
 )
+urls_views["source-service_offering-detail"] = None
+urls_views["source-service_offering-order"] = None
+urls_views["source-service_offering-applied-inventories-tags"] = None
 
 offerings = router.register("service_offerings", ServiceOfferingViewSet)
 offerings.register(
@@ -45,10 +54,7 @@ offerings.register(
     basename="offering-service_plans",
     parents_query_lookups=["service_offering"],
 )
+urls_views["offering-service_plans-detail"] = None
 
 router.register("service_inventories", ServiceInventoryViewSet)
 router.register("service_plans", ServicePlanViewSet)
-
-urlpatterns = [
-    path("", include((router.urls, "inventory"))),
-]


### PR DESCRIPTION
When use drf-extension to support nested urls, the second level model automatically get all endpoints that the model supports when it is the first level. We want to control precisely what endpoint urls and http methods are available when a model is in first level or second level in the path.

This PR allows to remove all unwanted endpoints, and modify allowed http methods.

https://issues.redhat.com/browse/SSP-2345