### PR TITLE
Use QuerySetMixin for all catalog and inventory views

### DIFF
--- a/main/approval/views.py
+++ b/main/approval/views.py
@@ -72,7 +72,7 @@ class WorkflowViewSet(
                 max_obj.internal_sequence.to_integral_value() + 1
             )
         serializer.save(
-            template=Template(id=self.kwargs["parent_lookup_template"]),
+            template=Template(id=self.kwargs[self.parent_lookup_key]),
             internal_sequence=next_seq,
             tenant=Tenant.current(),
         )
@@ -128,7 +128,7 @@ class ActionViewSet(QuerySetMixin, viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(
-            request=Request(id=self.kwargs["parent_lookup_request"]),
+            request=Request(id=self.kwargs[self.parent_lookup_key]),
             user=self.request.user,
             tenant=Tenant.current(),
         )

--- a/main/catalog/tests/factories.py
+++ b/main/catalog/tests/factories.py
@@ -9,7 +9,7 @@ from main.catalog.models import (
     PortfolioItem,
     ProgressMessage,
 )
-from main.tests.factories import TenantFactory, UserFactory
+from main.tests.factories import TenantFactory, UserFactory, default_tenant
 
 
 class PortfolioFactory(factory.django.DjangoModelFactory):
@@ -18,7 +18,7 @@ class PortfolioFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Portfolio
 
-    tenant = factory.SubFactory(TenantFactory)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
     name = factory.Sequence(lambda n: f"portfolio{n}")
     description = factory.Sequence(lambda n: f"portfolio{n}_description")
 
@@ -29,8 +29,8 @@ class PortfolioItemFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = PortfolioItem
 
-    tenant = factory.SubFactory(TenantFactory)
-    portfolio = factory.SubFactory(PortfolioFactory, tenant=tenant)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
+    portfolio = factory.SubFactory(PortfolioFactory)
     name = factory.Sequence(lambda n: f"portfolio_item{n}")
     description = factory.Sequence(lambda n: f"portfolio_item{n}_description")
     service_offering_ref = factory.Sequence(lambda n: f"service_offering_{n}")
@@ -42,7 +42,7 @@ class OrderFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Order
 
-    tenant = factory.SubFactory(TenantFactory)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
     user = factory.SubFactory(UserFactory)
 
 
@@ -52,9 +52,9 @@ class OrderItemFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = OrderItem
 
-    tenant = factory.SubFactory(TenantFactory)
-    order = factory.SubFactory(OrderFactory, tenant=tenant)
-    portfolio_item = factory.SubFactory(PortfolioItemFactory, tenant=tenant)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
+    order = factory.SubFactory(OrderFactory)
+    portfolio_item = factory.SubFactory(PortfolioItemFactory)
     user = factory.SubFactory(UserFactory)
     name = factory.Sequence(lambda n: f"order_item{n}")
 
@@ -65,8 +65,8 @@ class ApprovalRequestFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ApprovalRequest
 
-    tenant = factory.SubFactory(TenantFactory)
-    order = factory.SubFactory(OrderFactory, tenant=tenant)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
+    order = factory.SubFactory(OrderFactory)
     reason = factory.Sequence(lambda n: f"reason_{n}")
     approval_request_ref = factory.Sequence(
         lambda n: f"approval_request_ref{n}"
@@ -79,5 +79,5 @@ class ProgressMessageFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ProgressMessage
 
-    tenant = factory.SubFactory(TenantFactory)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
     message = factory.Sequence(lambda n: f"message_{n}")

--- a/main/catalog/tests/functional/test_order_end_points.py
+++ b/main/catalog/tests/functional/test_order_end_points.py
@@ -3,7 +3,6 @@ import json
 import pytest
 from django.urls import reverse
 
-from main.tests.factories import TenantFactory
 from main.catalog.tests.factories import (
     OrderFactory,
     OrderItemFactory,
@@ -71,7 +70,6 @@ def test_order_put_not_supported(api_request):
 @pytest.mark.django_db
 def test_order_post(api_request):
     """Create a Order"""
-    TenantFactory()
     data = {"name": "abcdef", "description": "abc"}
     response = api_request("post", reverse("order-list"), data)
     content = json.loads(response.content)

--- a/main/catalog/tests/functional/test_portfolio_end_points.py
+++ b/main/catalog/tests/functional/test_portfolio_end_points.py
@@ -6,7 +6,6 @@ import os
 import glob
 
 from django.urls import reverse
-from main.tests.factories import TenantFactory
 from main.catalog.tests.factories import PortfolioFactory
 from main.catalog.tests.factories import PortfolioItemFactory
 
@@ -74,7 +73,6 @@ def test_portfolio_put_not_supported(api_request):
 @pytest.mark.django_db
 def test_portfolio_post(api_request):
     """Create a Portfolio"""
-    TenantFactory()
     data = {"name": "abcdef", "description": "abc"}
     response = api_request("post", reverse("portfolio-list"), data)
 
@@ -84,12 +82,11 @@ def test_portfolio_post(api_request):
 @pytest.mark.django_db
 def test_portfolio_portfolio_items_get(api_request):
     """List PortfolioItems by portfolio id"""
-    tenant = TenantFactory()
-    portfolio1 = PortfolioFactory(tenant=tenant)
-    portfolio2 = PortfolioFactory(tenant=tenant)
-    PortfolioItemFactory(portfolio=portfolio1, tenant=tenant)
-    PortfolioItemFactory(portfolio=portfolio1, tenant=tenant)
-    portfolio_item3 = PortfolioItemFactory(portfolio=portfolio2, tenant=tenant)
+    portfolio1 = PortfolioFactory()
+    portfolio2 = PortfolioFactory()
+    PortfolioItemFactory(portfolio=portfolio1)
+    PortfolioItemFactory(portfolio=portfolio1)
+    portfolio_item3 = PortfolioItemFactory(portfolio=portfolio2)
 
     response = api_request(
         "get", reverse("portfolio-portfolioitem-list", args=(portfolio2.id,))
@@ -108,8 +105,7 @@ def test_portfolio_icon_post(api_request, small_image, media_dir):
     image_path = os.path.join(media_dir, "*.png")
     orignal_images = glob.glob(image_path)
 
-    tenant = TenantFactory()
-    portfolio = PortfolioFactory(tenant=tenant)
+    portfolio = PortfolioFactory()
     data = {"icon": small_image, "source_ref": "abc"}
 
     assert portfolio.icon is None
@@ -136,8 +132,7 @@ def test_portfolio_icon_patch(api_request, small_image, media_dir):
     """Update a icon image for a portfolio"""
     image_path = os.path.join(media_dir, "*.png")
 
-    tenant = TenantFactory()
-    portfolio = PortfolioFactory(tenant=tenant)
+    portfolio = PortfolioFactory()
 
     data = {"icon": small_image, "source_ref": "abc"}
 
@@ -171,8 +166,7 @@ def test_portfolio_icon_delete(api_request, small_image, media_dir):
     image_path = os.path.join(media_dir, "*.png")
     orignal_images = glob.glob(image_path)
 
-    tenant = TenantFactory()
-    portfolio = PortfolioFactory(tenant=tenant)
+    portfolio = PortfolioFactory()
 
     data = {"icon": small_image, "source_ref": "abc"}
 

--- a/main/catalog/urls.py
+++ b/main/catalog/urls.py
@@ -22,14 +22,18 @@ class NestedDefaultRouter(NestedRouterMixin, routers.DefaultRouter):
 router = NestedDefaultRouter()
 
 router.register("tenants", TenantViewSet)
-portfolios = router.register(r"portfolios", PortfolioViewSet)
+portfolios = router.register(
+    r"portfolios", PortfolioViewSet, basename="portfolio"
+)
 portfolios.register(
     r"portfolio_items",
     PortfolioItemViewSet,
     basename="portfolio-portfolioitem",
     parents_query_lookups=["portfolio"],
 )
-router.register(r"portfolio_items", PortfolioItemViewSet)
+router.register(
+    r"portfolio_items", PortfolioItemViewSet, basename="portfolioitem"
+)
 urls_views["portfolio-portfolioitem-detail"] = None  # disable
 urls_views["portfolio-portfolioitem-icon"] = None
 urls_views["portfolio-portfolioitem-tag"] = None
@@ -39,7 +43,7 @@ urls_views["portfolio-portfolioitem-list"] = PortfolioItemViewSet.as_view(
     {"get": "list"}
 )  # read only
 
-orders = router.register(r"orders", OrderViewSet)
+orders = router.register(r"orders", OrderViewSet, basename="order")
 orders.register(
     r"order_items",
     OrderItemViewSet,
@@ -64,7 +68,9 @@ urls_views["order-orderitem-detail"] = OrderItemViewSet.as_view(
 urls_views["order-approvalrequest-detail"] = None
 urls_views["order-progressmessage-detail"] = None
 
-order_items = router.register(r"order_items", OrderItemViewSet)
+order_items = router.register(
+    r"order_items", OrderItemViewSet, basename="orderitem"
+)
 order_items.register(
     r"progress_messages",
     ProgressMessageViewSet,

--- a/main/inventory/tests/factories.py
+++ b/main/inventory/tests/factories.py
@@ -2,7 +2,7 @@
 import factory
 from django.utils import timezone
 from main.models import Source
-from main.tests.factories import TenantFactory
+from main.tests.factories import TenantFactory, default_tenant
 from main.inventory.models import ServiceInventory
 from main.inventory.models import ServiceOffering, OfferingKind
 from main.inventory.models import ServicePlan
@@ -15,7 +15,7 @@ class SourceFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Source
 
-    tenant = factory.SubFactory(TenantFactory)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
     name = factory.Sequence(lambda n: f"source{n}")
 
 
@@ -25,8 +25,8 @@ class ServiceInventoryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ServiceInventory
 
-    tenant = factory.SubFactory(TenantFactory)
-    source = factory.SubFactory(SourceFactory, tenant=tenant)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
+    source = factory.SubFactory(SourceFactory)
     name = factory.Sequence(lambda n: f"inventory{n}")
     source_created_at = timezone.now()
     source_updated_at = timezone.now()
@@ -40,8 +40,8 @@ class ServiceOfferingFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ServiceOffering
 
-    tenant = factory.SubFactory(TenantFactory)
-    source = factory.SubFactory(SourceFactory, tenant=tenant)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
+    source = factory.SubFactory(SourceFactory)
     service_inventory = factory.SubFactory(
         ServiceInventoryFactory, tenant=tenant, source=source
     )
@@ -60,8 +60,8 @@ class ServicePlanFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ServicePlan
 
-    tenant = factory.SubFactory(TenantFactory)
-    source = factory.SubFactory(SourceFactory, tenant=tenant)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
+    source = factory.SubFactory(SourceFactory)
     service_offering = factory.SubFactory(
         ServiceOfferingFactory,
         tenant=tenant,
@@ -81,8 +81,8 @@ class ServiceOfferingNodeFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ServiceOfferingNode
 
-    tenant = factory.SubFactory(TenantFactory)
-    source = factory.SubFactory(SourceFactory, tenant=tenant)
+    tenant = factory.LazyAttribute(lambda _: default_tenant())
+    source = factory.SubFactory(SourceFactory)
     service_offering = factory.SubFactory(
         ServiceOfferingFactory,
         tenant=tenant,

--- a/main/inventory/urls.py
+++ b/main/inventory/urls.py
@@ -17,7 +17,7 @@ class NestedDefaultRouter(NestedRouterMixin, routers.DefaultRouter):
 
 
 router = NestedDefaultRouter()
-sources = router.register(r"sources", SourceViewSet)
+sources = router.register(r"sources", SourceViewSet, basename="source")
 sources.register(
     r"service_inventories",
     ServiceInventoryViewSet,
@@ -47,7 +47,9 @@ urls_views["source-service_offering-detail"] = None
 urls_views["source-service_offering-order"] = None
 urls_views["source-service_offering-applied-inventories-tags"] = None
 
-offerings = router.register("service_offerings", ServiceOfferingViewSet)
+offerings = router.register(
+    "service_offerings", ServiceOfferingViewSet, basename="serviceoffering"
+)
 offerings.register(
     r"service_plans",
     ServicePlanViewSet,
@@ -56,5 +58,7 @@ offerings.register(
 )
 urls_views["offering-service_plans-detail"] = None
 
-router.register("service_inventories", ServiceInventoryViewSet)
-router.register("service_plans", ServicePlanViewSet)
+router.register(
+    "service_inventories", ServiceInventoryViewSet, basename="serviceinventory"
+)
+router.register("service_plans", ServicePlanViewSet, basename="serviceplan")


### PR DESCRIPTION
Previously the queryset attribute does not filter tenant and parent relationship. Switch to use QueryMixin that implements `get_queryset` method which has been used by approval.