### PR TITLE
Move black config outside of tox.ini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 79
+target-version = ['py38']
+

--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,11 @@ commands = pytest {posargs}
 
 [testenv:black]
 commands =
-  black -v -l79 {toxinidir}
+  black -v {toxinidir}
 
 [testenv:linters]
 commands =
-  black -v -l79 --diff --check {toxinidir}
+  black -v --diff --check {toxinidir}
   flake8 {posargs}
 
 [testenv:venv]


### PR DESCRIPTION
Move black configuration to the project level. It allows calling
black as a standalone tool outside of a tox environment.