### PR TITLE
Use @extend_schema to identify proper types in openapi spec

### DIFF
--- a/ansible_catalog/urls.py
+++ b/ansible_catalog/urls.py
@@ -18,6 +18,11 @@ from django.urls import include, path
 from rest_framework import routers
 from django.conf import settings
 from django.conf.urls.static import static
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 
 from main.catalog.urls import (
     router as catalog_router,
@@ -52,5 +57,16 @@ urls_views = {**catalog_views, **approval_views, **inventory_views}
 urls_patterns = [p for p in urls_patterns if __filter_by_view(p)]
 
 urlpatterns = [
+    path(r"api/v1/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        r"api/v1/schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+    path(
+        r"api/v1/schema/redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="redoc",
+    ),
     path(r"api/v1/", include(urls_patterns)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/common/image_mixin.py
+++ b/common/image_mixin.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.decorators import action
+from drf_spectacular.utils import extend_schema
 
 from main.catalog.serializers import ImageSerializer
 from main.models import Image
@@ -14,6 +15,14 @@ class ImageMixin:
     Image mixin shared with Catalog Portfolio and PortfolioItem
     """
 
+    @extend_schema(
+        request=ImageSerializer, responses=ImageSerializer, methods=("PATCH",)
+    )
+    @extend_schema(
+        request=ImageSerializer,
+        responses={201: ImageSerializer},
+        methods=("POST",),
+    )
     @action(methods=["post", "patch", "delete"], detail=True)
     def icon(self, request, pk):
         """

--- a/common/tag_mixin.py
+++ b/common/tag_mixin.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.decorators import action
+from drf_spectacular.utils import extend_schema
 
 from .serializers import TagSerializer
 
@@ -12,6 +13,9 @@ class TagMixin:
     Tag mixin shared with Approval, Catalog and Inventory
     """
 
+    @extend_schema(
+        responses={200: TagSerializer(many=True)},
+    )
     @action(methods=["get"], detail=True)
     def tags(self, request, pk):
         """
@@ -24,6 +28,7 @@ class TagMixin:
 
         return Response(data)
 
+    @extend_schema(request=TagSerializer, responses={201: TagSerializer})
     @action(methods=["post"], detail=True)
     def tag(self, request, pk):
         """
@@ -44,6 +49,10 @@ class TagMixin:
             tag_serializer.errors, status=status.HTTP_400_BAD_REQUEST
         )
 
+    @extend_schema(
+        request=TagSerializer,
+        responses={204: None},
+    )
     @action(methods=["post"], detail=True)
     def untag(self, request, pk):
         """

--- a/main/approval/serializers.py
+++ b/main/approval/serializers.py
@@ -7,6 +7,7 @@ from main.approval.models import (
     Request,
     RequestContext,
     Action,
+    TagLink,
 )
 from main.approval.services.create_request import CreateRequest
 
@@ -114,4 +115,20 @@ class RequestCompleteSerializer(serializers.ModelSerializer):
 
 RequestCompleteSerializer._declared_fields[
     "sub_requests"
-] = RequestCompleteSerializer(many=True)
+] = RequestCompleteSerializer(many=True, read_only=True)
+
+
+class ResourceObjectSerializer(serializers.ModelSerializer):
+    """Serializer for Linking Workflow"""
+
+    app_name = serializers.CharField(required=True, write_only=True)
+    object_type = serializers.CharField(required=True, write_only=True)
+    object_id = serializers.CharField(required=True, write_only=True)
+
+    class Meta:
+        model = TagLink
+        fields = (
+            "object_type",
+            "object_id",
+            "app_name",
+        )

--- a/main/catalog/views.py
+++ b/main/catalog/views.py
@@ -9,6 +9,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework_extensions.mixins import NestedViewSetMixin
 from rest_framework.response import Response
 from rest_framework import status
+from drf_spectacular.utils import extend_schema
 
 from common.tag_mixin import TagMixin
 from common.image_mixin import ImageMixin
@@ -110,6 +111,10 @@ class OrderViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
     )
     search_fields = ("state",)
 
+    @extend_schema(
+        request=None,
+        responses={204: None},
+    )
     @action(methods=["post"], detail=True)
     def submit(self, request, pk):
         """Orders the specified pk order."""
@@ -127,6 +132,10 @@ class OrderViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     # TODO:
+    @extend_schema(
+        request=None,
+        responses={204: None},
+    )
     @action(methods=["patch"], detail=True)
     def cancel(self, request, pk):
         """Cancels the specified pk order."""


### PR DESCRIPTION
A few endpoints in the auto generated openapi spec do not have the correct input or output type. All non standard CRUD methods implemented by customized `@action` have such problem, such icon and tag endpoints. Request creation is also a special case where the input and output are of different types.

drf-spectacular provides `extend_schema` for explicit input and output types.

https://issues.redhat.com/browse/SSP-2347

Also enable three new endpoints:
api/v1/schema/ - Download the openapi spec in yaml format
api/v1/schema/swagger-ui/
api/v1/schema/redoc/
We can decide whether to remove swagger-ui or redoc for production.
