### PR TITLE
Use SubrequestSerializer for subrequests

### DIFF
--- a/ansible_catalog/main/approval/models.py
+++ b/ansible_catalog/main/approval/models.py
@@ -119,7 +119,7 @@ class Request(BaseModel):
         "self",
         on_delete=models.CASCADE,
         null=True,
-        related_name="sub_requests",
+        related_name="subrequests",
     )
     request_context = models.ForeignKey(
         RequestContext, null=True, on_delete=models.SET_NULL

--- a/ansible_catalog/main/approval/serializers.py
+++ b/ansible_catalog/main/approval/serializers.py
@@ -99,8 +99,8 @@ class ActionSerializer(serializers.ModelSerializer):
         read_only_fields = ("created_at", "request")
 
 
-class RequestCompleteSerializer(serializers.ModelSerializer):
-    """Serializer for Request with nested actions and children"""
+class SubrequestSerializer(serializers.ModelSerializer):
+    """Serializer for sub request with actions"""
 
     actions = ActionSerializer(many=True, read_only=True)
 
@@ -109,13 +109,22 @@ class RequestCompleteSerializer(serializers.ModelSerializer):
         fields = (
             *RequestFields.FIELDS,
             "actions",
-            "sub_requests",
         )
 
 
-RequestCompleteSerializer._declared_fields[
-    "sub_requests"
-] = RequestCompleteSerializer(many=True, read_only=True)
+class RequestCompleteSerializer(serializers.ModelSerializer):
+    """Serializer for Request with actions and subrequests"""
+
+    actions = ActionSerializer(many=True, read_only=True)
+    subrequests = SubrequestSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Request
+        fields = (
+            *RequestFields.FIELDS,
+            "actions",
+            "subrequests",
+        )
 
 
 class ResourceObjectSerializer(serializers.ModelSerializer):

--- a/ansible_catalog/main/approval/tests/functional/test_requst_end_points.py
+++ b/ansible_catalog/main/approval/tests/functional/test_requst_end_points.py
@@ -118,7 +118,7 @@ def test_request_request_not_create(api_request):
         url,
         {
             "name": "child",
-            "description": "child request cannot be explictly created",
+            "description": "child request cannot be explicitly created",
             "parent": request.id,
         },
     )
@@ -137,12 +137,13 @@ def test_request_full_action(api_request):
     response = api_request("get", url)
     content = json.loads(response.content)
     assert response.status_code == 200
-    assert content["sub_requests"][0]["name"] == child.name
-    assert content["sub_requests"][0]["id"] == child.id
+    print(content)
+    assert content["subrequests"][0]["name"] == child.name
+    assert content["subrequests"][0]["id"] == child.id
     assert content["actions"][0]["operation"] == parent_action.operation
     assert content["actions"][0]["id"] == parent_action.id
     assert (
-        content["sub_requests"][0]["actions"][0]["operation"]
+        content["subrequests"][0]["actions"][0]["operation"]
         == child_action.operation
     )
-    assert content["sub_requests"][0]["actions"][0]["id"] == child_action.id
+    assert content["subrequests"][0]["actions"][0]["id"] == child_action.id

--- a/ansible_catalog/main/approval/views.py
+++ b/ansible_catalog/main/approval/views.py
@@ -195,7 +195,7 @@ class RequestViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
     )
     @action(methods=["get"], detail=True)
     def full(self, request, pk):
-        """Details of a request with its sub_requests and actions"""
+        """Details of a request with its subrequests and actions"""
         instance = self.get_object()
         serializer = RequestCompleteSerializer(instance)
         return Response(serializer.data)


### PR DESCRIPTION
follow up https://issues.redhat.com/browse/SSP-2347

Introduce a dedicated serializer for subrequests to avoid circular reference.

Also change attribute name from `sub_requests` to `subrequests`.