### PR TITLE
Rename ViewSet filter_fields

### DIFF
--- a/main/approval/views.py
+++ b/main/approval/views.py
@@ -99,7 +99,7 @@ class WorkflowViewSet(
         OrderingFilter,
         SearchFilter,
     )
-    filter_fields = (
+    filterset_fields = (
         "name",
         "description",
         "template",
@@ -163,7 +163,7 @@ class RequestViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
     http_method_names = ["get", "post"]
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = "__all__"
+    filterset_fields = "__all__"
     search_fields = ("name", "description", "state", "decision", "reason")
     parent_field_name = "parent"
     parent_lookup_key = "parent_lookup_parent"
@@ -208,7 +208,7 @@ class ActionViewSet(QuerySetMixin, viewsets.ModelViewSet):
     http_method_names = ["get", "post"]
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = "__all__"
+    filterset_fields = "__all__"
     search_fields = ("operation", "comments")
     parent_field_name = "request"
     parent_lookup_key = "parent_lookup_request"

--- a/main/catalog/views.py
+++ b/main/catalog/views.py
@@ -51,7 +51,7 @@ class TenantViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = TenantSerializer
     permission_classes = (IsAuthenticated,)
     ordering = ("id",)
-    filter_fields = "__all__"
+    filterset_fields = "__all__"
 
 
 class PortfolioViewSet(
@@ -67,7 +67,7 @@ class PortfolioViewSet(
     http_method_names = ["get", "post", "head", "patch", "delete"]
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = ("name", "description", "created_at", "updated_at")
+    filterset_fields = ("name", "description", "created_at", "updated_at")
     search_fields = ("name", "description")
 
 
@@ -84,7 +84,7 @@ class PortfolioItemViewSet(
     http_method_names = ["get", "post", "head", "patch", "delete"]
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = (
+    filterset_fields = (
         "name",
         "description",
         "service_offering_ref",
@@ -104,7 +104,7 @@ class OrderViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
     http_method_names = ["get", "post", "head", "delete"]
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = (
+    filterset_fields = (
         "state",
         "order_request_sent_at",
         "created_at",
@@ -153,7 +153,7 @@ class OrderItemViewSet(
     http_method_names = ["get", "post", "head", "delete"]
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = (
+    filterset_fields = (
         "name",
         "count",
         "state",
@@ -180,7 +180,7 @@ class ApprovalRequestViewSet(
     http_method_names = ["get"]
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = (
+    filterset_fields = (
         "order",
         "approval_request_ref",
         "state",
@@ -211,7 +211,7 @@ class ProgressMessageViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     http_method_names = ["get"]
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = (
+    filterset_fields = (
         "received_at",
         "messageable_id",
         "messageable_type",
@@ -245,7 +245,7 @@ class CatalogServicePlanViewSet(
     http_method_names = ["get", "patch", "post", "head"]
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = (
+    filterset_fields = (
         "name",
         "description",
         "portfolio_item",

--- a/main/inventory/views.py
+++ b/main/inventory/views.py
@@ -37,7 +37,7 @@ class SourceViewSet(NestedViewSetMixin, QuerySetMixin, ModelViewSet):
     serializer_class = SourceSerializer
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = ("name",)
+    filterset_fields = ("name",)
     search_fields = ("name",)
 
     # Enable PATCH for refresh API
@@ -58,7 +58,7 @@ class ServicePlanViewSet(NestedViewSetMixin, QuerySetMixin, ModelViewSet):
     serializer_class = ServicePlanSerializer
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = (
+    filterset_fields = (
         "name",
         "service_offering",
     )
@@ -75,7 +75,7 @@ class ServiceOfferingViewSet(NestedViewSetMixin, QuerySetMixin, ModelViewSet):
     serializer_class = ServiceOfferingSerializer
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = (
+    filterset_fields = (
         "name",
         "description",
         "survey_enabled",
@@ -106,7 +106,7 @@ class ServiceInventoryViewSet(
     serializer_class = ServiceInventorySerializer
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = (
+    filterset_fields = (
         "description",
         "source_ref",
         "source_created_at",
@@ -128,7 +128,7 @@ class ServiceInstanceViewSet(QuerySetMixin, ModelViewSet):
     serializer_class = ServiceInstanceSerializer
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filter_fields = (
+    filterset_fields = (
         "name",
         "source_ref",
         "source_created_at",


### PR DESCRIPTION
This change fixes deprecation warnings raised by django-filter library:

```
MigrationNotice: `RequestViewSet.filter_fields` attribute should be renamed `filterset_fields`.
See: https://django-filter.readthedocs.io/en/master/guide/migration.html
```