### PR TITLE
Was missing the KEYCLOAK_SECRET in the worker deployment

### DIFF
--- a/tools/minikube/templates/worker-deployment.yaml
+++ b/tools/minikube/templates/worker-deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: redis
             - name: KEYCLOAK_URL
               value: http://keycloak:8080/auth
+            - name: KEYCLOAK_SECRET
+              value: SOMESECRETVALUE
             - name: KEYCLOAK_USER
               value: admin
             - name: KEYCLOAK_PASSWORD


### PR DESCRIPTION
The app deployment was setting the secret but the worker deployment
was using the default, causing authorization failures.