### PR TITLE
change default apispec format to json

### DIFF
--- a/ansible_catalog/urls.py
+++ b/ansible_catalog/urls.py
@@ -19,7 +19,7 @@ from rest_framework import routers
 from django.conf import settings
 from django.conf.urls.static import static
 from drf_spectacular.views import (
-    SpectacularAPIView,
+    SpectacularJSONAPIView,
     SpectacularRedocView,
     SpectacularSwaggerView,
 )
@@ -57,7 +57,7 @@ urls_views = {**catalog_views, **approval_views, **inventory_views}
 urls_patterns = [p for p in urls_patterns if __filter_by_view(p)]
 
 urlpatterns = [
-    path(r"api/v1/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(r"api/v1/schema/", SpectacularJSONAPIView.as_view(), name="schema"),
     path(
         r"api/v1/schema/swagger-ui/",
         SpectacularSwaggerView.as_view(url_name="schema"),


### PR DESCRIPTION
Change the default format of the apispec to json for more convenience and integration with IQE and CRC. 