### PR TITLE
Change propagate to false for Django logger

### DIFF
--- a/ansible_catalog/settings/defaults.py
+++ b/ansible_catalog/settings/defaults.py
@@ -250,7 +250,7 @@ LOGGING = {
     "loggers": {
         "django": {
             "handlers": ["console"],
-            "propagate": True,
+            "propagate": False,
         },
         "django.request": {
             "handlers": ["console", "file"],


### PR DESCRIPTION
Change `propagate` to `False` for Django logger.

https://issues.redhat.com/browse/SSP-2348