### PR TITLE
Fix keycloak access token expiration

### DIFF
--- a/ansible_catalog/common/auth/keycloak_oidc.py
+++ b/ansible_catalog/common/auth/keycloak_oidc.py
@@ -41,6 +41,10 @@ class KeycloakOpenIdConnect(OpenIdConnectAuth):
     """
 
     name = "keycloak-oidc"
+    EXTRA_DATA = [
+        *OpenIdConnectAuth.EXTRA_DATA,
+        ('expires_in', 'expires'),
+    ]
 
     @property
     def OIDC_ENDPOINT(self):


### PR DESCRIPTION
Access token expiration time from Keycloak response
was not populated to user.extra_data and thus
UserMixin.get_access_token() did not work correctly.