### PR TITLE
Fix create_json_schema in service plan to JSON object

### DIFF
--- a/ansible_catalog/main/inventory/task_utils/service_plan_import.py
+++ b/ansible_catalog/main/inventory/task_utils/service_plan_import.py
@@ -3,7 +3,6 @@
     format and saves it in the DB
 """
 
-import json
 from django.utils import timezone
 from ansible_catalog.main.inventory.models import ServicePlan
 
@@ -29,7 +28,7 @@ class ServicePlanImport:
         now = timezone.now()
         ServicePlan.objects.create(
             source_ref=source_ref,
-            create_json_schema=json.dumps(ddf_data),
+            create_json_schema=ddf_data,
             source=self.source,
             tenant=self.tenant,
             service_offering_id=service_offering_id,


### PR DESCRIPTION
This PR changes the` create_json_schema` field in `ServicePlan` from string type into a JSON object, as the definition in open API spec.

https://issues.redhat.com/browse/SSP-2404