### PR TITLE
Change parent lookup name pattern to {parent}_id

### DIFF
--- a/ansible_catalog/common/nested_router.py
+++ b/ansible_catalog/common/nested_router.py
@@ -1,0 +1,19 @@
+"""Default nested router with a patched parent path variable name"""
+from rest_framework_extensions import utils
+
+
+def parent_pk_kwarg_name(value):
+    """more meaningful parent path variable name and compatible with drf-spectacular"""
+    return f"{value}_id"
+
+
+utils.compose_parent_pk_kwarg_name = parent_pk_kwarg_name
+
+
+# Do NOT move the following from to top of the file
+from rest_framework_extensions.routers import NestedRouterMixin
+from rest_framework.routers import DefaultRouter
+
+
+class NestedDefaultRouter(NestedRouterMixin, DefaultRouter):
+    pass

--- a/ansible_catalog/common/queryset_mixin.py
+++ b/ansible_catalog/common/queryset_mixin.py
@@ -11,17 +11,18 @@ class QuerySetMixin:
     def get_queryset(self):
         """filter by current tenant and query_lookup_key, order by queryset_order_by"""
 
-        parent_lookup_key = getattr(self, "parent_lookup_key", None)
-        parent_field_name = getattr(self, "parent_field_name", None)
+        parent_field_names = getattr(self, "parent_field_names", [])
         queryset_order_by = getattr(self, "queryset_order_by", None)
         serializer_class = self.get_serializer_class() or self.serializer_class
         queryset = serializer_class.Meta.model.objects.filter(
             tenant=Tenant.current()
         )
-        if parent_lookup_key in self.kwargs:
-            queryset = queryset.filter(
-                **{parent_field_name: self.kwargs[parent_lookup_key]}
-            )
+        for parent_field_name in parent_field_names:
+            parent_lookup_key = f"{parent_field_name}_id"
+            if parent_lookup_key in self.kwargs:
+                queryset = queryset.filter(
+                    **{parent_field_name: self.kwargs[parent_lookup_key]}
+                )
         if queryset_order_by is not None:
             queryset = queryset.order_by(queryset_order_by)
         return queryset

--- a/ansible_catalog/main/approval/urls.py
+++ b/ansible_catalog/main/approval/urls.py
@@ -1,7 +1,5 @@
 """URLs for approval"""
-from rest_framework.routers import DefaultRouter
-from rest_framework_extensions.routers import NestedRouterMixin
-
+from ansible_catalog.common.nested_router import NestedDefaultRouter
 from ansible_catalog.main.approval.views import (
     TemplateViewSet,
     WorkflowViewSet,
@@ -11,19 +9,13 @@ from ansible_catalog.main.approval.views import (
 
 urls_views = {}
 
-
-class NestedDefaultRouter(NestedRouterMixin, DefaultRouter):
-    pass
-
-
 router = NestedDefaultRouter()
-
 templates = router.register("templates", TemplateViewSet, basename="template")
 templates.register(
     "workflows",
     WorkflowViewSet,
     basename="template-workflow",
-    parents_query_lookups=["template"],
+    parents_query_lookups=WorkflowViewSet.parent_field_names,
 )
 urls_views["template-workflow-detail"] = None  # disable
 urls_views["template-workflow-link"] = None
@@ -39,13 +31,13 @@ requests.register(
     "actions",
     ActionViewSet,
     basename="request-action",
-    parents_query_lookups=["request"],
+    parents_query_lookups=ActionViewSet.parent_field_names,
 )
 requests.register(
     "requests",
     RequestViewSet,
     basename="request-request",
-    parents_query_lookups=["parent"],
+    parents_query_lookups=RequestViewSet.parent_field_names,
 )
 urls_views["request-action-detail"] = None  # disable
 urls_views["request-request-detail"] = None

--- a/ansible_catalog/main/approval/views.py
+++ b/ansible_catalog/main/approval/views.py
@@ -111,8 +111,7 @@ class WorkflowViewSet(
         "updated_at",
     )
     search_fields = ("name", "description")
-    parent_field_name = "template"
-    parent_lookup_key = "parent_lookup_template"
+    parent_field_names = ("template",)
     queryset_order_by = "internal_sequence"
 
     @extend_schema(
@@ -154,7 +153,7 @@ class WorkflowViewSet(
                 max_obj.internal_sequence.to_integral_value() + 1
             )
         serializer.save(
-            template=Template(id=self.kwargs[self.parent_lookup_key]),
+            template=Template(id=self.kwargs["template_id"]),
             internal_sequence=next_seq,
             tenant=Tenant.current(),
         )
@@ -169,8 +168,7 @@ class RequestViewSet(NestedViewSetMixin, QuerySetMixin, viewsets.ModelViewSet):
     ordering = ("-id",)
     filterset_fields = "__all__"
     search_fields = ("name", "description", "state", "decision", "reason")
-    parent_field_name = "parent"
-    parent_lookup_key = "parent_lookup_parent"
+    parent_field_names = ("parent",)
 
     @extend_schema(
         request=RequestInSerializer,
@@ -210,12 +208,11 @@ class ActionViewSet(QuerySetMixin, viewsets.ModelViewSet):
     ordering = ("-id",)
     filterset_fields = "__all__"
     search_fields = ("operation", "comments")
-    parent_field_name = "request"
-    parent_lookup_key = "parent_lookup_request"
+    parent_field_names = ("request",)
 
     def perform_create(self, serializer):
         serializer.save(
-            request=self.kwargs[self.parent_lookup_key],
+            request=self.kwargs["request_id"],
             user=self.request.user,
             tenant=Tenant.current(),
         )

--- a/ansible_catalog/main/catalog/urls.py
+++ b/ansible_catalog/main/catalog/urls.py
@@ -1,7 +1,5 @@
-from rest_framework import routers
-
-from rest_framework_extensions.routers import NestedRouterMixin
-
+"""URLs for catalog"""
+from ansible_catalog.common.nested_router import NestedDefaultRouter
 from ansible_catalog.main.catalog.views import (
     ApprovalRequestViewSet,
     CatalogServicePlanViewSet,
@@ -15,13 +13,7 @@ from ansible_catalog.main.catalog.views import (
 
 urls_views = {}
 
-
-class NestedDefaultRouter(NestedRouterMixin, routers.DefaultRouter):
-    pass
-
-
 router = NestedDefaultRouter()
-
 router.register("tenants", TenantViewSet)
 portfolios = router.register(
     r"portfolios", PortfolioViewSet, basename="portfolio"
@@ -30,7 +22,7 @@ portfolios.register(
     r"portfolio_items",
     PortfolioItemViewSet,
     basename="portfolio-portfolioitem",
-    parents_query_lookups=["portfolio"],
+    parents_query_lookups=PortfolioItemViewSet.parent_field_names,
 )
 portfolio_items = router.register(
     r"portfolio_items", PortfolioItemViewSet, basename="portfolioitem"
@@ -48,7 +40,7 @@ portfolio_items.register(
     r"service_plans",
     CatalogServicePlanViewSet,
     basename="portfolioitem-serviceplan",
-    parents_query_lookups=["portfolio_item"],
+    parents_query_lookups=CatalogServicePlanViewSet.parent_field_names,
 )
 
 urls_views["portfolioitem-serviceplan-detail"] = None  # disable
@@ -61,19 +53,19 @@ orders.register(
     r"order_items",
     OrderItemViewSet,
     basename="order-orderitem",
-    parents_query_lookups=["order"],
+    parents_query_lookups=OrderItemViewSet.parent_field_names,
 )
 orders.register(
     r"approval_request",
     ApprovalRequestViewSet,
     basename="order-approvalrequest",
-    parents_query_lookups=["order"],
+    parents_query_lookups=ApprovalRequestViewSet.parent_field_names,
 )
 orders.register(
     r"progress_messages",
     ProgressMessageViewSet,
     basename="order-progressmessage",
-    parents_query_lookups=["messageable_id"],
+    parents_query_lookups=["messageable"],
 )
 urls_views["order-orderitem-detail"] = OrderItemViewSet.as_view(
     {"get": "retrieve"}
@@ -88,7 +80,7 @@ order_items.register(
     r"progress_messages",
     ProgressMessageViewSet,
     basename="orderitem-progressmessage",
-    parents_query_lookups=["messageable_id"],
+    parents_query_lookups=["messageable"],
 )
 urls_views["orderitem-list"] = None
 urls_views["orderitem-progressmessage-detail"] = None

--- a/ansible_catalog/main/catalog/views.py
+++ b/ansible_catalog/main/catalog/views.py
@@ -102,8 +102,7 @@ class PortfolioItemViewSet(
         "updated_at",
     )
     search_fields = ("name", "description")
-    parent_field_name = "portfolio"
-    parent_lookup_key = "parent_lookup_portfolio"
+    parent_field_names = ("portfolio",)
 
     @extend_schema(
         responses={200: PortfolioItemSerializer},
@@ -194,8 +193,7 @@ class OrderItemViewSet(
         "completed_at",
     )
     search_fields = ("name", "state")
-    parent_field_name = "order"
-    parent_lookup_key = "parent_lookup_order"
+    parent_field_names = ("order",)
 
 
 class ApprovalRequestViewSet(
@@ -221,11 +219,10 @@ class ApprovalRequestViewSet(
         "state",
         "reason",
     )
-    parent_field_name = "order"
-    parent_lookup_key = "parent_lookup_order"
+    parent_field_names = ("order",)
 
     def list(self, request, *args, **kwargs):
-        order_id = kwargs.pop(self.parent_lookup_key)
+        order_id = kwargs.pop("order_id")
         approval_request = ApprovalRequest.objects.get(order_id=order_id)
 
         serializer = self.get_serializer(approval_request)
@@ -241,8 +238,6 @@ class ProgressMessageViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     ordering = ("-id",)
     filterset_fields = (
         "received_at",
-        "messageable_id",
-        "messageable_type",
         "level",
         "created_at",
         "updated_at",
@@ -253,8 +248,7 @@ class ProgressMessageViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
 
         path_splits = self.request.path.split("/")
         parent_type = path_splits[path_splits.index("progress_messages") - 2]
-        messageable_id = self.kwargs.get("parent_lookup_messageable_id")
-
+        messageable_id = self.kwargs.get("messageable_id")
         messageable_type = "Order" if parent_type == "orders" else "OrderItem"
 
         return ProgressMessage.objects.filter(
@@ -279,14 +273,13 @@ class CatalogServicePlanViewSet(
         "portfolio_item",
     )
     search_fields = ("name",)
-    parent_field_name = "portfolio_item"
-    parent_lookup_key = "parent_lookup_portfolio_item"
+    parent_field_names = ("portfolio_item",)
 
     @extend_schema(
         responses={200: CatalogServicePlanSerializer},
     )
     def list(self, request, *args, **kwargs):
-        portfolio_item_id = kwargs.pop(self.parent_lookup_key)
+        portfolio_item_id = kwargs.pop("portfolio_item_id")
         portfolio_item = PortfolioItem.objects.get(id=portfolio_item_id)
 
         service_plans = (

--- a/ansible_catalog/main/inventory/urls.py
+++ b/ansible_catalog/main/inventory/urls.py
@@ -1,7 +1,5 @@
 """URLs for Inventory"""
-from rest_framework import routers
-
-from rest_framework_extensions.routers import NestedRouterMixin
+from ansible_catalog.common.nested_router import NestedDefaultRouter
 from ansible_catalog.main.inventory.views import (
     ServiceInstanceViewSet,
     ServiceInventoryViewSet,
@@ -12,18 +10,13 @@ from ansible_catalog.main.inventory.views import (
 
 urls_views = {}
 
-
-class NestedDefaultRouter(NestedRouterMixin, routers.DefaultRouter):
-    pass
-
-
 router = NestedDefaultRouter()
 sources = router.register(r"sources", SourceViewSet, basename="source")
 sources.register(
     r"service_inventories",
     ServiceInventoryViewSet,
     basename="source-service_inventory",
-    parents_query_lookups=["source"],
+    parents_query_lookups=ServiceInventoryViewSet.parent_field_names,
 )
 urls_views["source-service_inventory-detail"] = None  # disable
 urls_views["source-service_inventory-tag"] = None
@@ -34,7 +27,7 @@ sources.register(
     r"service_plans",
     ServicePlanViewSet,
     basename="source-service_plan",
-    parents_query_lookups=["source"],
+    parents_query_lookups=(ServicePlanViewSet.parent_field_names[1],),
 )
 urls_views["source-service_plan-detail"] = None
 
@@ -42,7 +35,7 @@ sources.register(
     r"service_offerings",
     ServiceOfferingViewSet,
     basename="source-service_offering",
-    parents_query_lookups=["source"],
+    parents_query_lookups=ServiceOfferingViewSet.parent_field_names,
 )
 urls_views["source-service_offering-detail"] = None
 urls_views["source-service_offering-order"] = None
@@ -55,7 +48,7 @@ offerings.register(
     r"service_plans",
     ServicePlanViewSet,
     basename="offering-service_plans",
-    parents_query_lookups=["service_offering"],
+    parents_query_lookups=(ServicePlanViewSet.parent_field_names[0],),
 )
 urls_views["offering-service_plans-detail"] = None
 

--- a/ansible_catalog/main/inventory/views.py
+++ b/ansible_catalog/main/inventory/views.py
@@ -63,9 +63,7 @@ class ServicePlanViewSet(NestedViewSetMixin, QuerySetMixin, ModelViewSet):
         "service_offering",
     )
     search_fields = ("name",)
-    # TODO: service plan has another parent called service. This endpoint may no longer be needed
-    parent_field_name = "service_offering"
-    parent_lookup_key = "parent_lookup_service_offering"
+    parent_field_names = ("service_offering", "source") # do not modify the sequence
     http_method_names = ["get", "head"]
 
 
@@ -83,8 +81,7 @@ class ServiceOfferingViewSet(NestedViewSetMixin, QuerySetMixin, ModelViewSet):
         "service_inventory",
     )
     search_fields = ("name", "description")
-    parent_field_name = "source"
-    parent_lookup_key = "parent_lookup_source"
+    parent_field_names = ("source",)
     http_method_names = ["get", "head"]
 
     # TODO:
@@ -115,8 +112,7 @@ class ServiceInventoryViewSet(
         "updated_at",
     )
     search_fields = ("description",)
-    parent_field_name = "source"
-    parent_lookup_key = "parent_lookup_source"
+    parent_field_names = ("source",)
 
     # For tagging purpose, enable POST action here
     http_method_names = ["get", "post", "head"]


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2377

Given the example of nested URL for portfolio/portfolio_item, the default pattern by drf-extentions is
```
portfolios/{parent_lookup_portfolio}/portfolio_items
```
drf-spectacular is having difficulty to resolve the type of {parent_lookup_portfolio} and default it to string.

This work changes the pattern to 
```
portfolios/{portfolio_id}/portfolio_items
```
drf-spectacular is now able to resolve type of {portfolio_id} to integer. Also the name is aligned with our cloud API.

It requires the latest version of drf-spectacular.