### PR TITLE
Enable to copy a portfolio

### DIFF
--- a/ansible_catalog/main/catalog/services/copy_image.py
+++ b/ansible_catalog/main/catalog/services/copy_image.py
@@ -1,0 +1,43 @@
+"""Copy Image service"""
+import logging
+import os
+import random
+import string
+from django.core.files.base import ContentFile
+
+from ansible_catalog.main.catalog.models import Image
+
+
+logger = logging.getLogger("catalog")
+
+
+class CopyImage:
+    """Copy image service"""
+
+    def __init__(self, image):
+        self.icon = image
+        self.new_icon = None
+
+    def process(self):
+        existing_image_names = [
+            image.file.name for image in Image.objects.all()
+        ]
+        names = os.path.splitext(self.icon.file.name)
+
+        while True:
+            rad_sfx = "".join(
+                random.choices(string.ascii_letters + string.digits, k=6)
+            )
+            new_name = "{}{}{}".format(names[0], rad_sfx, names[-1])
+            if new_name not in existing_image_names:
+                break
+
+        with open(self.icon.file.path, "rb") as icon:
+            data = icon.read()
+
+        self.new_icon = Image()
+        self.new_icon.file.save(new_name, ContentFile(data))
+        self.new_icon.source_ref = self.icon.source_ref
+        self.new_icon.save()
+
+        return self

--- a/ansible_catalog/main/catalog/services/copy_portfolio.py
+++ b/ansible_catalog/main/catalog/services/copy_portfolio.py
@@ -1,0 +1,73 @@
+"""Copy portfolio service"""
+import copy
+import logging
+from django.db import transaction
+
+from ansible_catalog.main.catalog.models import (
+    Portfolio,
+    PortfolioItem,
+)
+from ansible_catalog.main.catalog.services import (
+    name,
+)
+from ansible_catalog.main.catalog.services.copy_image import (
+    CopyImage,
+)
+from ansible_catalog.main.catalog.services.copy_portfolio_item import (
+    CopyPortfolioItem,
+)
+
+
+logger = logging.getLogger("catalog")
+
+
+class CopyPortfolio:
+    """Copy portfolio service"""
+
+    def __init__(self, portfolio, options):
+        self.portfolio = portfolio
+        self.name = options.get("portfolio_name", portfolio.name)
+
+        self.new_portfolio = None
+
+    def process(self):
+        self.make_copy()
+
+        return self
+
+    @transaction.atomic
+    def make_copy(self):
+        new_icon = (
+            CopyImage(self.portfolio.icon).process().new_icon
+            if self.portfolio.icon
+            else None
+        )
+
+        self.new_portfolio = copy.copy(self.portfolio)
+        self.new_portfolio.id = None
+        self.new_portfolio.name = self._new_portfolio_name()
+        self.new_portfolio.icon = new_icon
+        self.new_portfolio.save()
+
+        portfolio_items = PortfolioItem.objects.filter(
+            portfolio=self.portfolio
+        )
+        for item in portfolio_items:
+            try:
+                CopyPortfolioItem(item, {}).process()
+            except Exception as error:
+                logger.error(
+                    "Failed to copy portfolio item %d: %s", item.id, str(error)
+                )
+                raise
+
+    def _new_portfolio_name(self):
+        portfolio_names = [
+            portfolio.name for portfolio in Portfolio.objects.all()
+        ]
+
+        return (
+            name.create_copy_name(self.name, portfolio_names)
+            if self.name in portfolio_names
+            else self.name
+        )

--- a/ansible_catalog/main/catalog/tests/factories.py
+++ b/ansible_catalog/main/catalog/tests/factories.py
@@ -1,6 +1,9 @@
 """ Factory for catalog objects """
+from django.db.models.fields.files import ImageFieldFile, FileField
+import os
 import factory
 
+from ansible_catalog.main.models import Image
 from ansible_catalog.main.catalog.models import (
     ApprovalRequest,
     CatalogServicePlan,
@@ -93,3 +96,17 @@ class ServicePlanFactory(factory.django.DjangoModelFactory):
     portfolio_item = factory.SubFactory(PortfolioItemFactory)
 
     name = factory.Sequence(lambda n: f"catalog service_plan_{n}")
+
+
+class ImageFactory(factory.django.DjangoModelFactory):
+    """Image Factory"""
+
+    class Meta:
+        model = Image
+
+    source_ref = factory.Sequence(lambda n: f"image_{n}")
+    file = ImageFieldFile(
+        instance=None,
+        field=FileField(),
+        name=os.path.basename("redhat_icon.png"),
+    )

--- a/ansible_catalog/main/catalog/tests/services/test_copy_image.py
+++ b/ansible_catalog/main/catalog/tests/services/test_copy_image.py
@@ -1,0 +1,25 @@
+"""Test copy image service"""
+import pytest
+
+from ansible_catalog.main.models import (
+    Image,
+)
+from ansible_catalog.main.catalog.tests.factories import (
+    ImageFactory,
+)
+from ansible_catalog.main.catalog.services.copy_image import (
+    CopyImage,
+)
+
+
+@pytest.mark.django_db
+def test_copy_image(small_image):
+    image = ImageFactory()
+
+    assert Image.objects.count() == 1
+
+    svc = CopyImage(image)
+    svc.process()
+
+    assert Image.objects.count() == 2
+    assert Image.objects.first().file.name != Image.objects.last().file.name

--- a/ansible_catalog/main/catalog/tests/services/test_copy_portfolio.py
+++ b/ansible_catalog/main/catalog/tests/services/test_copy_portfolio.py
@@ -1,0 +1,70 @@
+"""Test copy portfolio service"""
+from unittest.mock import patch
+import pytest
+
+from ansible_catalog.main.models import (
+    Image,
+)
+from ansible_catalog.main.catalog.models import (
+    Portfolio,
+    PortfolioItem,
+)
+from ansible_catalog.main.catalog.services.copy_portfolio import (
+    CopyPortfolio,
+)
+from ansible_catalog.main.catalog.tests.factories import (
+    ImageFactory,
+    PortfolioFactory,
+    PortfolioItemFactory,
+)
+
+
+@pytest.mark.django_db
+def test_portfolio_copy():
+    portfolio = PortfolioFactory()
+    options = {
+        "portfolio_name": "my test",
+    }
+
+    svc = CopyPortfolio(portfolio, options)
+    svc.process()
+
+    assert Portfolio.objects.count() == 2
+    assert svc.new_portfolio.name == "my test"
+
+
+@pytest.mark.django_db
+def test_portfolio_copy_with_portfolio_items():
+    portfolio = PortfolioFactory()
+    PortfolioItemFactory(portfolio=portfolio)
+
+    with patch(
+        "ansible_catalog.main.catalog.services.copy_portfolio_item.CopyPortfolioItem._is_orderable"
+    ) as mock:
+        mock.return_value = True
+        svc = CopyPortfolio(portfolio, {})
+        svc.process()
+
+    assert Portfolio.objects.count() == 2
+    assert PortfolioItem.objects.count() == 2
+    assert svc.new_portfolio.name == "Copy of %s" % portfolio.name
+    assert (
+        PortfolioItem.objects.last().name
+        == "Copy of %s" % PortfolioItem.objects.first().name
+    )
+
+
+@pytest.mark.django_db
+def test_portfolio_copy_with_icon():
+    image = ImageFactory()
+    portfolio = PortfolioFactory(icon=image)
+
+    assert Image.objects.count() == 1
+
+    svc = CopyPortfolio(portfolio, {})
+    svc.process()
+
+    assert Portfolio.objects.count() == 2
+    assert Image.objects.count() == 2
+    assert Portfolio.objects.first().icon == Image.objects.first()
+    assert Portfolio.objects.last().icon == Image.objects.last()

--- a/ansible_catalog/main/catalog/tests/services/test_copy_portfolio_item.py
+++ b/ansible_catalog/main/catalog/tests/services/test_copy_portfolio_item.py
@@ -1,9 +1,6 @@
 """Test copy portfolio item service"""
 import pytest
 
-from ansible_catalog.main.models import (
-    Image,
-)
 from ansible_catalog.main.catalog.models import (
     CatalogServicePlan,
     PortfolioItem,


### PR DESCRIPTION
Enable endpoint `portfolios/:id/copy` with POST action to copy a portfolio.

https://issues.redhat.com/browse/SSP-2280