### PR TITLE
Return 404 when parent id is an invalid integer

### DIFF
--- a/ansible_catalog/common/queryset_mixin.py
+++ b/ansible_catalog/common/queryset_mixin.py
@@ -1,5 +1,7 @@
 """provides a common implementation of get_queryset method in viewset"""
 
+from django.http import Http404
+
 from ansible_catalog.main.models import Tenant
 
 
@@ -20,9 +22,12 @@ class QuerySetMixin:
         for parent_field_name in parent_field_names:
             parent_lookup_key = f"{parent_field_name}_id"
             if parent_lookup_key in self.kwargs:
-                queryset = queryset.filter(
-                    **{parent_field_name: self.kwargs[parent_lookup_key]}
-                )
+                try:
+                    queryset = queryset.filter(
+                        **{parent_field_name: self.kwargs[parent_lookup_key]}
+                    )
+                except ValueError:
+                    raise Http404
         if queryset_order_by is not None:
             queryset = queryset.order_by(queryset_order_by)
         return queryset

--- a/ansible_catalog/main/catalog/tests/functional/test_portfolio_end_points.py
+++ b/ansible_catalog/main/catalog/tests/functional/test_portfolio_end_points.py
@@ -91,6 +91,25 @@ def test_portfolio_portfolio_items_get(api_request):
 
 
 @pytest.mark.django_db
+def test_portfolio_portfolio_items_get_bad_id(api_request):
+    """List PortfolioItems by non-existing id"""
+    response = api_request("get", "portfolio-portfolioitem-list", -1)
+
+    assert response.status_code == 200
+    content = json.loads(response.content)
+
+    assert content["count"] == 0
+
+
+@pytest.mark.django_db
+def test_portfolio_portfolio_items_get_string_id(api_request):
+    """List PortfolioItems by fake string id"""
+    response = api_request("get", "portfolio-portfolioitem-list", "abc")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
 def test_portfolio_icon_post(api_request, small_image, media_dir):
     """Create a icon image for a portfolio"""
     image_path = os.path.join(media_dir, "*.png")


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2379

When query nested resources such as `portfolio/<id>/portfolio-items` with non-integer id such as `abc`, the backend raises a 500 error. We could raise 400 error with error saying `abc` is an invalid key. This fix here follows the same way how the drf-extensions handles the ValueError where it converts to 404 instead. See https://github.com/chibisov/drf-extensions/blob/master/rest_framework_extensions/mixins.py#L64