### PR TITLE
Allow to set api prefix through env CATALOG_API_PATH_PREFIX

### DIFF
--- a/ansible_catalog/settings/defaults.py
+++ b/ansible_catalog/settings/defaults.py
@@ -36,7 +36,9 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-CATALOG_API_PATH_PREFIX = "/api/ansible-catalog"
+CATALOG_API_PATH_PREFIX = env.str(
+    "ANSIBLE_CATALOG_API_PATH_PREFIX", default="/api/ansible-catalog"
+)
 
 # Application definition
 


### PR DESCRIPTION
follow up issue https://issues.redhat.com/browse/SSP-2417