### PR TITLE
Remove nested copy url for portfolio items

### DIFF
--- a/ansible_catalog/main/catalog/urls.py
+++ b/ansible_catalog/main/catalog/urls.py
@@ -32,6 +32,7 @@ urls_views["portfolio-portfolioitem-icon"] = None
 urls_views["portfolio-portfolioitem-tag"] = None
 urls_views["portfolio-portfolioitem-tags"] = None
 urls_views["portfolio-portfolioitem-untag"] = None
+urls_views["portfolio-portfolioitem-copy"] = None
 urls_views["portfolio-portfolioitem-list"] = PortfolioItemViewSet.as_view(
     {"get": "list"}
 )  # read only


### PR DESCRIPTION
Removed nested url: `/api/ansible-catalog/v1/portfolios/:id/portfolio_items/:id/copy/`


https://issues.redhat.com/browse/SSP-2489