### PR TITLE
PortfolioItem's icon_url allows null in openapi.json

### DIFF
--- a/ansible_catalog/main/catalog/serializers.py
+++ b/ansible_catalog/main/catalog/serializers.py
@@ -64,7 +64,9 @@ class PortfolioItemSerializer(serializers.ModelSerializer):
     """Serializer for PortfolioItem, which maps to a Tower Job Template
     via the service_offering_ref."""
 
-    icon_url = serializers.SerializerMethodField("get_icon_url")
+    icon_url = serializers.SerializerMethodField(
+        "get_icon_url", allow_null=True
+    )
 
     class Meta:
         model = PortfolioItem


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2403

Add missing allow_null=True for PortfolioItem icon_url attribute.