### PR TITLE
Make OrderItem name attribute read only

### DIFF
--- a/ansible_catalog/main/approval/tests/functional/test_requst_end_points.py
+++ b/ansible_catalog/main/approval/tests/functional/test_requst_end_points.py
@@ -106,7 +106,6 @@ def test_create_action(api_request, mocker):
         {
             "operation": "Deny",
             "comments": "not good",
-            "request": request.id,
         },
     )
 

--- a/ansible_catalog/main/catalog/models.py
+++ b/ansible_catalog/main/catalog/models.py
@@ -273,6 +273,7 @@ class OrderItemManager(models.Manager):
             SanitizeParameters,
         )
 
+        kwargs["name"] = kwargs["portfolio_item"].name
         order_item = super(OrderItemManager, self).create(*args, **kwargs)
 
         sanitized_parameters = (

--- a/ansible_catalog/main/catalog/serializers.py
+++ b/ansible_catalog/main/catalog/serializers.py
@@ -152,7 +152,7 @@ class OrderItemSerializer(serializers.ModelSerializer):
             "updated_at",
             "completed_at",
         )
-        read_only_fields = ("created_at", "updated_at", "order")
+        read_only_fields = ("created_at", "updated_at", "order", "name")
         extra_kwargs = {
             "completed_at": {"allow_null": True},
             "order_request_sent_at": {"allow_null": True},

--- a/ansible_catalog/main/catalog/tests/functional/test_order_end_points.py
+++ b/ansible_catalog/main/catalog/tests/functional/test_order_end_points.py
@@ -47,8 +47,9 @@ def test_order_delete(api_request):
 
 
 @pytest.mark.django_db
-def test_order_submit(api_request):
+def test_order_submit(api_request, mocker):
     """Submit a single order by id"""
+    mocker.patch("django_rq.enqueue")
     service_offering = ServiceOfferingFactory()
     portfolio = PortfolioFactory()
     portfolio_item = PortfolioItemFactory(
@@ -159,9 +160,10 @@ def test_order_order_item_post(api_request):
     order = OrderFactory()
     portfolio_item = PortfolioItemFactory()
     data = {
-        "order": order.id,  # TODO: remove order from data
         "portfolio_item": portfolio_item.id,
-        "name": "abcdef",
     }
     response = api_request("post", "order-orderitem-list", order.id, data)
+    content = json.loads(response.content)
     assert response.status_code == 201
+    assert content["name"] == portfolio_item.name
+    assert content["order"] == str(order.id)


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2531

The `name` field in `OrderItem` is readonly. Its value is copied from the corresponding `portfolio_item`.

@Alex-Izquierdo the `portfolio_item` is still required to create an `OrderItem`