### PR TITLE
Revert PR#139: Remove endpoint /order_items

### DIFF
--- a/ansible_catalog/main/catalog/tests/functional/test_order_item_end_points.py
+++ b/ansible_catalog/main/catalog/tests/functional/test_order_item_end_points.py
@@ -17,18 +17,6 @@ def test_order_item_retrieve(api_request):
 
 
 @pytest.mark.django_db
-def test_order_item_list(api_request):
-    """Get list of Order Items"""
-    OrderItemFactory()
-    response = api_request("get", "orderitem-list")
-
-    assert response.status_code == 200
-    content = json.loads(response.content)
-
-    assert content["count"] == 1
-
-
-@pytest.mark.django_db
 def test_order_item_delete(api_request):
     """Delete a OrderItem by id"""
     order_item = OrderItemFactory()

--- a/ansible_catalog/main/catalog/urls.py
+++ b/ansible_catalog/main/catalog/urls.py
@@ -83,6 +83,7 @@ order_items.register(
     basename="orderitem-progressmessage",
     parents_query_lookups=["messageable"],
 )
+urls_views["orderitem-list"] = None
 urls_views["orderitem-progressmessage-detail"] = None
 
 service_plans = router.register(


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2509
This endpoint is no longer needed with the help of #152