### PR TITLE
Some survey specs might not have default key

### DIFF
--- a/ansible_catalog/main/inventory/task_utils/spec_to_ddf.py
+++ b/ansible_catalog/main/inventory/task_utils/spec_to_ddf.py
@@ -40,7 +40,7 @@ class SpecToDDF:
         result = {
             "label": field["question_name"],
             "name": field["variable"],
-            "initial_value": field["default"],
+            "initial_value": field.get("default", ""),
             "helper_text": field["question_description"],
             "is_required": field["required"],
         }

--- a/ansible_catalog/main/inventory/tests/task_utils/test_spec_to_ddf.py
+++ b/ansible_catalog/main/inventory/tests/task_utils/test_spec_to_ddf.py
@@ -171,6 +171,24 @@ class TestSpecToDDF:
     }
     """
 
+    testdata9 = """
+    {
+        "name": "",
+        "description": "",
+        "spec": [
+           {
+                "question_name": "CPU",
+                "question_description": "Select a CPU",
+                "required": true,
+                "type": "multiplechoice",
+                "variable": "cpu",
+                "min": null,
+                "max": null,
+                "choices": "3"
+            }
+           ]
+    }
+    """
     result1 = {"component": "select-field"}
     result2 = {"data_type": "integer"}
     result3 = {"data_type": "float"}
@@ -179,6 +197,7 @@ class TestSpecToDDF:
     result6 = {"component": "text-field"}
     result7 = {"component": "select-field"}
     result8 = {"component": "select-field"}
+    result9 = {"component": "select-field"}
 
     @pytest.mark.parametrize(
         "test_input,expected",
@@ -191,6 +210,7 @@ class TestSpecToDDF:
             (testdata6, result6),
             (testdata7, result7),
             (testdata8, result8),
+            (testdata9, result9),
         ],
     )
     def test_conversion(self, test_input, expected):


### PR DESCRIPTION
Tower Surveys built via RESTAPI may not contain default key.
Set it to empty string if missing

Fixes #159