### PR TITLE
Set the Controller information from ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,10 @@ The ingress uses 2 hardcoded hosts **catalog** and **keycloak** to route the tra
 minikube image build -t localhost/ansible-catalog -f tools/docker/Dockerfile .
 ```
 ## Starting the app
-Once this has been setup you can start the deployments, services and ingress service in the directory tools/minikube/templates. A helper script creates a Kubernetes namespace called **catalog** and runs all the deployments in that namespace.
+Once this has been setup you can start the deployments, services and ingress service in the directory tools/minikube/templates. A helper script creates a Kubernetes namespace called **catalog** and runs all the deployments in that namespace. The helper scripts requires 3 environment variables to locate the Automation Controller.
+  - **export ANSIBLE_CATALOG_CONTROLLER_URL="Your controller url"**
+  - **export ANSIBLE_CATALOG_CONTROLLER_TOKEN="Your Token"**
+  - **export ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL="False"**
 
 ```
 ./tools/minikube/scripts/start_pods.sh

--- a/tools/minikube/scripts/start_pods.sh
+++ b/tools/minikube/scripts/start_pods.sh
@@ -1,4 +1,28 @@
 #!/bin/sh
+# For development purpose only
+# Set the environment variable for accessing your Automation Controller
+# export ANSIBLE_CATALOG_CONTROLLER_URL=<<your controller url>>
+# export ANSIBLE_CATALOG_CONTROLLER_TOKEN=<<your controller token>>
+# export ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL=True|False
+
+if [[ -z "${ANSIBLE_CATALOG_CONTROLLER_URL}" ]]
+then
+  echo "Please set the environment variable ANSIBLE_CATALOG_CONTROLLER_URL"
+  exit 1
+fi
+
+if [[ -z "${ANSIBLE_CATALOG_CONTROLLER_TOKEN}" ]]
+then
+  echo "Please set the environment variable ANSIBLE_CATALOG_CONTROLLER_TOKEN"
+  exit 1
+fi
+
+if [[ -z "${ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL}" ]]
+then
+  echo "Please set the environment variable ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL"
+  exit 1
+fi
+
 kubectl get namespace catalog 2>> /dev/null
 if [ $? -ne 0 ]; then
 	kubectl create namespace catalog
@@ -9,6 +33,12 @@ if [ $? -ne 0 ]; then
 	kubectl create --namespace=catalog configmap dbscripts --from-file=./tools/minikube/templates/scripts
 fi
 
+kubectl get configmap --namespace=catalog ansible-controller-env 2>> /dev/null
+if [ $? -eq 0 ]; then
+	kubectl delete --namespace=catalog configmap ansible-controller-env
+fi
+
+kubectl create configmap --namespace=catalog ansible-controller-env --from-literal=ANSIBLE_CATALOG_CONTROLLER_URL="$ANSIBLE_CATALOG_CONTROLLER_URL" --from-literal=ANSIBLE_CATALOG_CONTROLLER_TOKEN="$ANSIBLE_CATALOG_CONTROLLER_TOKEN" --from-literal=ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL="$ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL"
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/redis-deployment.yaml
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/redis-service.yaml
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/pg-data-persistentvolumeclaim.yaml

--- a/tools/minikube/templates/app-deployment.yaml
+++ b/tools/minikube/templates/app-deployment.yaml
@@ -63,6 +63,23 @@ spec:
               value: keycloak
             - name: ANSIBLE_CATALOG_POSTGRES_PASSWORD
               value: password
+            - name: ANSIBLE_CATALOG_CONTROLLER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: ansible-controller-env
+                  key: ANSIBLE_CATALOG_CONTROLLER_URL
+            - name: ANSIBLE_CATALOG_CONTROLLER_TOKEN
+              valueFrom:
+                configMapKeyRef:
+                  name: ansible-controller-env
+                  key: ANSIBLE_CATALOG_CONTROLLER_TOKEN
+            - name: ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL
+              valueFrom:
+                configMapKeyRef:
+                  name: ansible-controller-env
+                  key: ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL
+          image: localhost/ansible-catalog
+          image: localhost/ansible-catalog
           image: localhost/ansible-catalog
           imagePullPolicy: Never
           name: app

--- a/tools/minikube/templates/worker-deployment.yaml
+++ b/tools/minikube/templates/worker-deployment.yaml
@@ -55,6 +55,21 @@ spec:
               value: keycloak
             - name: ANSIBLE_CATALOG_POSTGRES_PASSWORD
               value: password
+            - name: ANSIBLE_CATALOG_CONTROLLER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: ansible-controller-env
+                  key: ANSIBLE_CATALOG_CONTROLLER_URL
+            - name: ANSIBLE_CATALOG_CONTROLLER_TOKEN
+              valueFrom:
+                configMapKeyRef:
+                  name: ansible-controller-env
+                  key: ANSIBLE_CATALOG_CONTROLLER_TOKEN
+            - name: ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL
+              valueFrom:
+                configMapKeyRef:
+                  name: ansible-controller-env
+                  key: ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL
           image: localhost/ansible-catalog
           imagePullPolicy: Never
           name: worker


### PR DESCRIPTION
Allows for a developer to set the Controller information in env
vars which flow via the ConfigMaps into the pod

  - **export ANSIBLE_CATALOG_CONTROLLER_URL="Your controller url"**
  - **export ANSIBLE_CATALOG_CONTROLLER_TOKEN="Your Token"**
  - **export ANSIBLE_CATALOG_CONTROLLER_VERIFY_SSL="False"**

```
./tools/minikube/scripts/start_pods.sh
```