### PR TITLE
Set DJANGO_SETTINGS_MODULE to be development

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,8 @@ on:
 
 jobs:
   build:
-
+    env:
+      DJANGO_SETTINGS_MODULE: ansible_catalog.settings.development
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Since we switched the database to be postgres from sqlite.
The pytest was failing looking for Postgres. Using development
settings we can use sqlite for pytest