### PR TITLE
Do not need to set name for order item

### DIFF
--- a/ansible_catalog/main/catalog/tests/factories.py
+++ b/ansible_catalog/main/catalog/tests/factories.py
@@ -58,7 +58,6 @@ class OrderItemFactory(factory.django.DjangoModelFactory):
     order = factory.SubFactory(OrderFactory)
     portfolio_item = factory.SubFactory(PortfolioItemFactory)
     user = factory.SubFactory(UserFactory)
-    name = factory.Sequence(lambda n: f"order_item{n}")
 
 
 class ApprovalRequestFactory(factory.django.DjangoModelFactory):

--- a/ansible_catalog/main/catalog/tests/unit/test_order_items.py
+++ b/ansible_catalog/main/catalog/tests/unit/test_order_items.py
@@ -26,38 +26,20 @@ def test_orderitem():
 
 
 @pytest.mark.django_db
-def test_empty_orderitem_name():
-    """Test empty name constraint on order item"""
-
-    tenant = TenantFactory()
-    user = UserFactory()
-    order = OrderFactory(tenant=tenant, user=user)
-    with pytest.raises(IntegrityError) as excinfo:
-        OrderItemFactory(tenant=tenant, user=user, order=order, name="")
-
-    assert (
-        f"CHECK constraint failed: {order._meta.app_label}_orderitem_name_empty"
-        in str(excinfo.value)
-    )
-
-
-@pytest.mark.django_db
 def test_duplicate_orderitem_name():
     """Test duplicate names constraint on order item"""
 
     tenant = TenantFactory()
     order = OrderFactory(tenant=tenant)
     portfolio_item = PortfolioItemFactory(tenant=tenant)
-    name = "fred"
     OrderItemFactory(
-        tenant=tenant, order=order, portfolio_item=portfolio_item, name=name
+        tenant=tenant, order=order, portfolio_item=portfolio_item
     )
     with pytest.raises(IntegrityError) as excinfo:
         OrderItemFactory(
             tenant=tenant,
             order=order,
             portfolio_item=portfolio_item,
-            name=name,
         )
 
     assert (


### PR DESCRIPTION
following up #154. In test there is no need to directly set name for order item. Also remove the test for the empty name. This helps to make the tests go green again.