### PR TITLE
Remove the keycloak seeding from workers

### DIFF
--- a/tools/keycloak_setup/dev_worker.yml
+++ b/tools/keycloak_setup/dev_worker.yml
@@ -1,7 +1,0 @@
----
-- hosts: localhost
-  vars:
-    settings_dir: "/home/appuser/catalog/ansible_catalog/settings/"
-    seed_keycloak: false
-  roles:
-    - mkanoor.catalog_keycloak.setup

--- a/tools/keycloak_setup/prod_worker.yml
+++ b/tools/keycloak_setup/prod_worker.yml
@@ -1,7 +1,0 @@
----
-- hosts: localhost
-  vars:
-    settings_dir: "/home/appuser/catalog/ansible_catalog/settings/"
-    seed_keycloak: false
-  roles:
-    - mkanoor.catalog_keycloak.setup


### PR DESCRIPTION
Now that we have keycloak oidc we dont need the separate settings
file for keycloak, all of that information flows thru environment
variables. We removed the worker interacting with keycloak during
setup in PR #156