### PR TITLE
Return a list of approval requests for an order

### DIFF
--- a/ansible_catalog/main/catalog/tests/functional/test_approval_request_end_points.py
+++ b/ansible_catalog/main/catalog/tests/functional/test_approval_request_end_points.py
@@ -11,15 +11,17 @@ def test_order_approval_request_get(api_request):
 
     response = api_request(
         "get",
-        "order-approvalrequest-list",
+        "order-approvalrequests-list",
         approval_request.order.id,
     )
 
     assert response.status_code == 200
 
     data = response.data
-    assert data["id"] == approval_request.id
+    assert data["count"] == 1
+    assert data["results"][0]["id"] == approval_request.id
     assert (
-        data["approval_request_ref"] == approval_request.approval_request_ref
+        data["results"][0]["approval_request_ref"]
+        == approval_request.approval_request_ref
     )
-    assert data["reason"] == approval_request.reason
+    assert data["results"][0]["reason"] == approval_request.reason

--- a/ansible_catalog/main/catalog/urls.py
+++ b/ansible_catalog/main/catalog/urls.py
@@ -57,9 +57,9 @@ orders.register(
     parents_query_lookups=OrderItemViewSet.parent_field_names,
 )
 orders.register(
-    r"approval_request",
+    r"approval_requests",
     ApprovalRequestViewSet,
-    basename="order-approvalrequest",
+    basename="order-approvalrequests",
     parents_query_lookups=ApprovalRequestViewSet.parent_field_names,
 )
 orders.register(
@@ -71,7 +71,7 @@ orders.register(
 urls_views["order-orderitem-detail"] = OrderItemViewSet.as_view(
     {"get": "retrieve"}
 )  # read only
-urls_views["order-approvalrequest-detail"] = None
+urls_views["order-approvalrequests-detail"] = None
 urls_views["order-progressmessage-detail"] = None
 
 order_items = router.register(

--- a/ansible_catalog/main/catalog/views.py
+++ b/ansible_catalog/main/catalog/views.py
@@ -327,13 +327,6 @@ class ApprovalRequestViewSet(
     )
     parent_field_names = ("order",)
 
-    def list(self, request, *args, **kwargs):
-        order_id = kwargs.pop("order_id")
-        approval_request = ApprovalRequest.objects.get(order_id=order_id)
-
-        serializer = self.get_serializer(approval_request)
-        return Response(serializer.data)
-
 
 class ProgressMessageViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     """API endpoint for listing progress messages."""


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2538

On the cloud version we have endpoint /order-items/<id>/approval-requests which returns a list.

On premise we changed to /orders/<id>/approval-request because each order has only one approval-request. The bug was the openapi.json that still describes the endpoint to return a list.

We could fix the openapi to return a single object. The question is what should we return if the order does not have an approval-request? The choice can be a 204 no content, or 404 resource does not exist. It seems 404 is better but if the order does not exist it returns 404 also.

The proposed fix is to change the endpoint to truly return a list. The list contains either a single object or no object. This is the same as the cloud version. It is not only backward compatible but also handles the situation when no approval-request exists for an order.