### PR TITLE
Logout a user from all sessions

### DIFF
--- a/ansible_catalog/common/auth/keycloak/admin.py
+++ b/ansible_catalog/common/auth/keycloak/admin.py
@@ -5,8 +5,8 @@ from . import models
 from . import openid
 from .client import ApiClient
 
-
 GROUPS_PATH = "admin/realms/{realm}/groups"
+LOGOUT_PATH = "admin/realms/{realm}/users/{id}/logout"
 
 
 class AdminClient:
@@ -21,6 +21,11 @@ class AdminClient:
         url = f"{self._server_url}/{path}"
         items = self._client.request_json("GET", url)
         return [models.Group.parse_obj(item) for item in items]
+
+    def logout_user(self, social_auth_id) -> None:
+        path = LOGOUT_PATH.format(realm=self._realm, id=social_auth_id)
+        url = f"{self._server_url}/{path}"
+        self._client.request("POST", url)
 
 
 def create_admin_client(

--- a/ansible_catalog/common/auth/keycloak/tests/unit/test_admin_client.py
+++ b/ansible_catalog/common/auth/keycloak/tests/unit/test_admin_client.py
@@ -1,7 +1,8 @@
 from unittest import mock
 
 import pytest
-
+from requests.models import Response
+from rest_framework import status
 from ansible_catalog.common.auth.keycloak import models
 from ansible_catalog.common.auth.keycloak.admin import AdminClient
 
@@ -79,3 +80,12 @@ def test_list_groups(api_client):
             ],
         ),
     ]
+
+
+def test_logout_user_200(api_client):
+    client = AdminClient(SERVER_URL, REALM, TOKEN)
+    response = mock.Mock(spec=Response)
+    response.status_code = 200
+
+    api_client.request.return_value = response
+    client.logout_user("10")

--- a/ansible_catalog/main/auth/tests/functional/test_logout_end_points.py
+++ b/ansible_catalog/main/auth/tests/functional/test_logout_end_points.py
@@ -1,0 +1,14 @@
+""" Module to test logout end point """
+import json
+import pytest
+from requests import Session
+
+
+@pytest.mark.django_db
+def test_logout(api_request, mocker):
+    """Logout an authenticated user"""
+    mocker.patch(
+        "ansible_catalog.common.auth.keycloak_django.clients.get_admin_client"
+    )
+    response = api_request("post", "logout")
+    assert response.status_code == 200

--- a/ansible_catalog/main/auth/urls.py
+++ b/ansible_catalog/main/auth/urls.py
@@ -1,3 +1,4 @@
+from django.urls import path
 from rest_framework.routers import SimpleRouter
 
 from ansible_catalog.main.auth import views
@@ -6,4 +7,7 @@ router = SimpleRouter()
 router.register("groups/sync", views.GroupSyncViewSet, basename="group-sync")
 router.register("groups", views.GroupViewSet)
 
-urlpatterns = router.urls
+urlpatterns = [
+    path("logout/", views.LogoutView.as_view(), name="logout"),
+]
+urlpatterns += router.urls

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@ import pytest
 import os
 import re
 import inspect
+from unittest.mock import Mock
 
 from django.urls import resolve, reverse
 from django.contrib.auth.models import User
@@ -45,6 +46,10 @@ def api_request(admin):
         )
         if user:
             force_authenticate(request, user=user)
+        request.session = Mock()
+        keycloak_mock = Mock()
+        keycloak_mock.extra_data = {"id": "1"}
+        request.keycloak_user = keycloak_mock
         response = view(request, *view_args, **view_kwargs)
         response.render()
         return response


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2568

Logout the user from Keycloak and catalog app
It requires manage-users role on Catalog Client Service Account
Uses
https://www.keycloak.org/docs-api/15.0/rest-api/index.html
POST /{realm}/users/{id}/logout

We get the ID from the UserSocialAuth object