### PR TITLE
Extra directory incorrectly added

### DIFF
--- a/ansible_catalog/settings/defaults.py
+++ b/ansible_catalog/settings/defaults.py
@@ -170,7 +170,6 @@ USE_TZ = True
 STATIC_URL = "/ui/"
 STATICFILES_DIRS = [
     BASE_DIR / "ui",
-    "/ui/",
 ]
 LOGIN_REDIRECT_URL = "/ui/index.html"
 


### PR DESCRIPTION
There was an extra dircetory in STATICFILES_DIRs causing this warning
message in the log
```
WARNINGS:
?: (staticfiles.W004) The directory '/ui/' in the STATICFILES_DIRS setting does not exist.
```

Added in PR #192 