### PR TITLE
Duplicate test names

### DIFF
--- a/ansible_catalog/main/auth/tests/functional/test_group_sync.py
+++ b/ansible_catalog/main/auth/tests/functional/test_group_sync.py
@@ -37,7 +37,7 @@ def test_group_sync_job_status(api_request, mocker):
 
 
 @pytest.mark.django_db
-def test_group_sync_job_status(api_request, mocker):
+def test_group_sync_missing_job_status(api_request, mocker):
     mocker.patch("django_rq.get_connection")
 
     job_id = str(uuid.uuid4())


### PR DESCRIPTION
test_group_sync_job_status was used twice.