### PR TITLE
Delete pv in minikube helper script when deleting namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,11 @@ This will stop the app and worker pods, build the image with latest changes and
 start the app and worker pods.
 
 ### Starting a fresh with a clean env 
-To delete all the pods and reset the application, run the helper_script delete_pods.sh
+To delete all the pods and reset the application, run the helper_script delete_pods.sh.
+The -d option deletes the persistent volumes so you can a fresh start
 
 ```
-./tools/minikube/scripts/delete_pods.sh
+./tools/minikube/scripts/delete_pods.sh -d
 ```
 
 ## About credentials

--- a/tools/minikube/scripts/delete_pods.sh
+++ b/tools/minikube/scripts/delete_pods.sh
@@ -1,7 +1,21 @@
 #!/bin/sh
-pvs=$(kubectl get pv | grep catalog/ | awk '{print $1}')
-kubectl delete namespace catalog
-for pv in "$pvs"
+while getopts dh flag
 do
-    kubectl delete pv $pv
+    case "${flag}" in
+        d) delete_pv=1;;
+        h) echo "usage: delete_pods.sh -d"; exit 0;
+    esac
 done
+
+if [ -n "$delete_pv" ]; then
+	pvs=($(kubectl get pv | grep catalog/ | awk '{print $1}'))
+fi
+
+kubectl delete namespace catalog
+
+if [ -n "$delete_pv" ]; then
+  for pv in "${pvs[@]}"
+  do
+    kubectl delete pv $pv 2> /dev/null
+  done
+fi


### PR DESCRIPTION
When testing we would like to delete the namespace and delete
all the databases associated with the namespace. The persistent
volumes were not getting deleted and we would reuse the existing
databases. This script collects the pv's for the catalog namespace
and deletes them when invoked with the -d option