### PR TITLE
Fixed minikube redeploy script

### DIFF
--- a/tools/minikube/scripts/redeploy_app.sh
+++ b/tools/minikube/scripts/redeploy_app.sh
@@ -6,8 +6,10 @@
 # they will be incorporated into the image.
 #
 set -e
+kubectl delete --namespace=catalog -f ./tools/minikube/templates/app-deployment.yaml
+kubectl delete --namespace=catalog -f ./tools/minikube/templates/worker-deployment.yaml
 echo "Rebuilding app image"
 eval $(minikube -p minikube docker-env)
 minikube image build -t localhost/ansible-catalog -f tools/docker/Dockerfile .
-kubectl rollout restart --namespace=catalog -f ./tools/minikube/templates/app-deployment.yaml
-kubectl rollout restart --namespace=catalog -f ./tools/minikube/templates/worker-deployment.yaml
+kubectl create --namespace=catalog -f ./tools/minikube/templates/app-deployment.yaml
+kubectl create --namespace=catalog -f ./tools/minikube/templates/worker-deployment.yaml


### PR DESCRIPTION
During development we might make changes to minikube template files
along with other source code changes. If we use kubectl rollout restart
it doesn't update the deployment. So fixed the script to delete
the deployment, do the build and re create the deployment.

We had used rollout restart in PR #203 