### PR TITLE
Allow for additional config parameters from env

### DIFF
--- a/ansible_catalog/settings/defaults.py
+++ b/ansible_catalog/settings/defaults.py
@@ -27,16 +27,12 @@ LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-_SECRET_KEY = (
-    "django-insecure-k8^atj4p3jj^zkb3=o(rhaysjzy_mr&#h(yl+ytj#f%@+er4&5"
-)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("ANSIBLE_CATALOG_DEBUG", default=False)
 TEMPLATE_DEBUG = DEBUG
 SQL_DEBUG = DEBUG
-SECRET_KEY = env.str("ANSIBLE_CATALOG_SECRET_KEY", default=_SECRET_KEY)
+SECRET_KEY = env.str("ANSIBLE_CATALOG_SECRET_KEY")
 
 ALLOWED_HOSTS = env.list("ANSIBLE_CATALOG_ALLOWED_HOSTS", default=[])
 

--- a/tools/minikube/templates/app-deployment.yaml
+++ b/tools/minikube/templates/app-deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: "*"
             - name: ANSIBLE_CATALOG_DEBUG
               value: "True"
+            - name: ANSIBLE_CATALOG_SECRET_KEY
+              value: "django-insecure-k8^atj4p3jj^zkb3=o(rhaysjzy_mr&#h(yl+ytj#f%@+er4&5"
             - name: ANSIBLE_CATALOG_CONTROLLER_URL
               valueFrom:
                 configMapKeyRef:

--- a/tools/minikube/templates/worker-deployment.yaml
+++ b/tools/minikube/templates/worker-deployment.yaml
@@ -63,6 +63,8 @@ spec:
               value: "*"
             - name: ANSIBLE_CATALOG_DEBUG
               value: "True"
+            - name: ANSIBLE_CATALOG_SECRET_KEY
+              value: "django-insecure-k8^atj4p3jj^zkb3=o(rhaysjzy_mr&#h(yl+ytj#f%@+er4&5"
             - name: ANSIBLE_CATALOG_CONTROLLER_URL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Previously we couldn't run by pointing

DJANGO_SETTINGS_MODULE=ansible.catalog.defaults

Because ALLOWED_HOSTS, SECRET_KEY and DEBUG were not picked up from the enviornment.

This PR allows ALLOWED_HOSTS, SECRET_KEY and DEBUG parameters to be
set from environment.

This was done mostly to get the production env working without
the split-settings package.

This introduces new environment variables which can be used

- ANSIBLE_CATALOG_ALLOWED_HOSTS default is []
- ANSIBLE_CATALOG_DEBUG default is False
- ANSIBLE_CATALOG_SECRET_KEY 