### PR TITLE
Honor workflow with no groups

### DIFF
--- a/ansible_catalog/main/approval/services/update_request.py
+++ b/ansible_catalog/main/approval/services/update_request.py
@@ -200,9 +200,4 @@ class UpdateRequest:
     def _should_auto_approve(self):
         if self.request.is_parent():
             return False
-        if (
-            self.request.workflow is None
-            or len(self.request.workflow.group_refs) == 0
-        ):
-            return True
-        return False
+        return self.request.workflow is None


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2642

A workflow without groups was treated as an empty workflow and got auto-approved. With this change such workflow is treated the same way as a normal workflow. It will not go through auto-approve.