### PR TITLE
Use a default value for DJANGO_SETTINGS_MODULE

### DIFF
--- a/ansible_catalog/asgi.py
+++ b/ansible_catalog/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "asc.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ansible_catalog.settings.defaults")
 
 application = get_asgi_application()

--- a/ansible_catalog/wsgi.py
+++ b/ansible_catalog/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "asc.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ansible_catalog.settings.defaults")
 
 application = get_wsgi_application()

--- a/tools/minikube/templates/app-deployment.yaml
+++ b/tools/minikube/templates/app-deployment.yaml
@@ -51,8 +51,6 @@ spec:
               value: http://app:8000,http://app:8000/*,*
             - name: CONTROLLER_VERIFY_SSL
               value: "False"
-            - name: DJANGO_SETTINGS_MODULE
-              value: ansible_catalog.settings.defaults
             - name: ANSIBLE_CATALOG_REDIS_HOST
               value: redis
             - name: ANSIBLE_CATALOG_REDIS_PORT

--- a/tools/minikube/templates/scheduler-deployment.yaml
+++ b/tools/minikube/templates/scheduler-deployment.yaml
@@ -49,8 +49,6 @@ spec:
               value: /tmp
             - name: CONTROLLER_VERIFY_SSL
               value: "False"
-            - name: DJANGO_SETTINGS_MODULE
-              value: ansible_catalog.settings.defaults
             - name: ANSIBLE_CATALOG_DATABASE_NAME
               value: dev_catalog
             - name: ANSIBLE_CATALOG_POSTGRES_HOST

--- a/tools/minikube/templates/worker-deployment.yaml
+++ b/tools/minikube/templates/worker-deployment.yaml
@@ -49,8 +49,6 @@ spec:
               value: /tmp
             - name: CONTROLLER_VERIFY_SSL
               value: "False"
-            - name: DJANGO_SETTINGS_MODULE
-              value: ansible_catalog.settings.defaults
             - name: ANSIBLE_CATALOG_DATABASE_NAME
               value: dev_catalog
             - name: ANSIBLE_CATALOG_POSTGRES_HOST


### PR DESCRIPTION
Set the default to be ansible_catalog.settings.defaults so
we don't have to pass it around in the environment variable