### PR TITLE
Temporarily auto notify all requests

### DIFF
--- a/ansible_catalog/main/approval/services/update_request.py
+++ b/ansible_catalog/main/approval/services/update_request.py
@@ -46,8 +46,9 @@ class UpdateRequest:
         ):
             self._update_parent()
 
-        if self._should_auto_approve():
-            self._notify_request()
+        # Temporarily auto notify all requests until notification is implemented
+        # if self._should_auto_approve():
+        self._notify_request()
 
     def _notified(self):
         self._persist_request("notified_at")

--- a/ansible_catalog/main/approval/tests/services/test_process_root_request.py
+++ b/ansible_catalog/main/approval/tests/services/test_process_root_request.py
@@ -32,7 +32,7 @@ def test_process_request_one_workflow(mocker):
     service = _prepare_service(mocker, [workflow.id])
     request = service.process().request
     _assert_request(
-        request, state="started", group_name="<NO_GROUP>", workflow=workflow
+        request, state="notified", group_name="<NO_GROUP>", workflow=workflow
     )
 
 
@@ -48,7 +48,7 @@ def test_process_request_one_workflow_one_group(mocker):
     service = _prepare_service(mocker, [workflow.id])
     request = service.process().request
     _assert_request(
-        request, state="started", group_name="n1", workflow=workflow
+        request, state="notified", group_name="n1", workflow=workflow
     )
     assert add_permissions.call_count == 1
 
@@ -93,11 +93,11 @@ def test_process_request_workflows_groups(mocker):
 
     request.refresh_from_db()
     _assert_request(
-        request, state="started", num_children=2, group_name="n1,<NO_GROUP>"
+        request, state="notified", num_children=2, group_name="n1,<NO_GROUP>"
     )
     _assert_request(
         request.requests[0],
-        state="started",
+        state="notified",
         group_name="n1",
         workflow=workflow1,
     )

--- a/ansible_catalog/main/approval/tests/services/test_update_request.py
+++ b/ansible_catalog/main/approval/tests/services/test_update_request.py
@@ -1,6 +1,7 @@
 """module to test updating request"""
 
 import pytest
+from unittest import skip
 from ansible_catalog.main.approval.models import Request, Action
 from ansible_catalog.main.approval.tests.factories import (
     RequestFactory,
@@ -13,6 +14,7 @@ from ansible_catalog.main.approval.services.update_request import (
 from ansible_catalog.main.approval.services.send_event import SendEvent
 
 
+@skip("until notification is implemented")
 @pytest.mark.django_db
 def test_update_single_request(mocker):
     """Test update state of a standalone request"""
@@ -87,6 +89,7 @@ def test_auto_approve(mocker):
     assert request.decision == Request.Decision.APPROVED
 
 
+@skip("until notification is implemented")
 @pytest.mark.django_db
 def test_update_child1(mocker):
     """Test updating first child with siblings and parent"""
@@ -170,6 +173,7 @@ def test_update_child1(mocker):
         assert child2.state == suite[2][2]
 
 
+@skip("until notification is implemented")
 @pytest.mark.django_db
 def test_update_child2(mocker):
     """Test updating last child with siblings and parent"""
@@ -307,6 +311,7 @@ def test_complete_canceled():
     assert child2.state == Request.State.SKIPPED
 
 
+@skip("until notification is implemented")
 @pytest.mark.django_db
 def test_update_parallel():
     """Test update a child in parallel group"""


### PR DESCRIPTION
Every request once started will automatically change to notified state until we implement the real notification.