### PR TITLE
Send the users current roles on /me request

### DIFF
--- a/ansible_catalog/main/auth/serializers.py
+++ b/ansible_catalog/main/auth/serializers.py
@@ -1,7 +1,10 @@
 from rest_framework import serializers
 
+import jwt
 from ansible_catalog.main.auth import models
 from django.contrib.auth.models import User
+from django.conf import settings
+from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 
 class GroupSerializer(serializers.ModelSerializer):
@@ -11,6 +14,24 @@ class GroupSerializer(serializers.ModelSerializer):
 
 
 class CurrentUserSerializer(serializers.ModelSerializer):
+    roles = serializers.SerializerMethodField("get_roles")
+
     class Meta:
         model = User
-        fields = ("username", "first_name", "last_name")
+        fields = ("username", "first_name", "last_name", "roles")
+
+    @extend_schema_field(
+        {"type": "array", "items": {"type": OpenApiTypes.STR}}
+    )
+    def get_roles(self, obj):
+        request = self.context.get("request")
+        extra_data = request.keycloak_user.extra_data
+        jot = jwt.decode(
+            extra_data["access_token"], options={"verify_signature": False}
+        )
+        roles = (
+            jot.get("resource_access", {})
+            .get(settings.KEYCLOAK_CLIENT_ID, {})
+            .get("roles", [])
+        )
+        return roles

--- a/ansible_catalog/main/auth/tests/functional/test_me_endpoint.py
+++ b/ansible_catalog/main/auth/tests/functional/test_me_endpoint.py
@@ -22,6 +22,7 @@ def test_current_me_authenticated(api_request):
     assert content["username"] == "fred"
     assert content["last_name"] == "Flintstone"
     assert content["first_name"] == "Fred"
+    assert sorted(content["roles"]) == ["approval-admin", "catalog-admin"]
 
 
 @pytest.mark.django_db

--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,8 @@ from django.contrib.auth.models import User
 
 from rest_framework.test import APIRequestFactory, force_authenticate
 
+DUMMY_ACCESS_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJjOGhQcFdtSk0wWmxYcXRvcnNScVVwcC1GYWNiOTl6UU44NHkzWkpmS0J3In0.eyJleHAiOjE2NDM4MTYwNzksImlhdCI6MTY0MzgxNTc3OSwiYXV0aF90aW1lIjoxNjQzODE1Nzc5LCJqdGkiOiJkY2FhYzYzOC0zNDk4LTQ5YzctYjM3NC1mMjE2MTg3NDcyMTIiLCJpc3MiOiJodHRwOi8va2V5Y2xvYWsudm0ubG9jYWw6ODA4MC9hdXRoL3JlYWxtcy9hYXAiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNzc3YmUyYWQtM2QyZi00ZWViLTliODgtZjhjNjViNWMxZDZkIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiY2F0YWxvZyIsIm5vbmNlIjoiTUxSemJPQ3FYTlU0MHp0ZFlLSnp6cTA4NUVRcnc4WElUbUxiVnpNblR2d0dvQVlTVXZRZ1piTVFYSllCbFNEbiIsInNlc3Npb25fc3RhdGUiOiIzNjk5ODJjNC03NTcxLTQ0MmYtODIwZC1iODJlZTRjZTFkMWQiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly9hcHA6ODAwMC8qIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIiwiZGVmYXVsdC1yb2xlcy1hYXAiXX0sInJlc291cmNlX2FjY2VzcyI6eyJjYXRhbG9nIjp7InJvbGVzIjpbImFwcHJvdmFsLWFkbWluIiwiY2F0YWxvZy1hZG1pbiJdfSwiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgcHJvZmlsZSBlbWFpbCIsInNpZCI6IjM2OTk4MmM0LTc1NzEtNDQyZi04MjBkLWI4MmVlNGNlMWQxZCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibmFtZSI6IkZyZWQgRmxpbnRzdG9uZSIsInByZWZlcnJlZF91c2VybmFtZSI6ImZyZWQiLCJnaXZlbl9uYW1lIjoiRnJlZCIsImZhbWlseV9uYW1lIjoiRmxpbnRzdG9uZSIsImVtYWlsIjoiZnJlZEBzbGF0ZXJvY2suY29tIn0.Nz1Ry8FUY2XCRQeVP-ihNAhaVKUELIsXYWKvlMyYRkHJBPQehtEgf5Chl_5HqcQ7QlxHtsg7jorB507z1kKoLsI6SXYBMBIMIPRF5CU2IqBv0yLxKnqp1u_pQdrnMcqNv3fPq2ZF0bE4ESYSUNTzglOE3A1jiIYf1H4BeK_Wyv44_SUuDQ0ghJHSCHWXhVtpStMczsnSfz_T7zja8QNaUO9lsz76DJZSXBfY3P8HYncsinw2H09wq58m5ZYpAIlN6HBifZ3v-VlHx2nSEITsL2ymBhz3HO8K7SAHnbakf_UTawTpDtYdqJSHce9-BPAU8M2bRzQ4Wa7U_O_S0R9-Mw"
+
 
 @pytest.fixture
 def normal_user():
@@ -58,8 +60,8 @@ def api_request(admin):
         keycloak_mock = Mock()
         keycloak_mock.extra_data = {
             "id": "1",
-            "access_token": "yabba dabba doo",
-            "refresh_token": "scooby doo",
+            "access_token": DUMMY_ACCESS_TOKEN,
+            "refresh_token": DUMMY_ACCESS_TOKEN,
         }
         request.keycloak_user = keycloak_mock
         response = view(request, *view_args, **view_kwargs)


### PR DESCRIPTION
When http://catalog.k8s.local/api/ansible-catalog/v1/me/
We now return the current users roles along with the username,
first_name and last_name.
e.g
```
{
    "username": "fred",
    "first_name": "Fred",
    "last_name": "Flintstone",
    "roles": [
        "approval-admin",
        "catalog-admin"
    ]
}
```

https://issues.redhat.com/browse/SSP-2702