### PR TITLE
Fetch the controllers version

### DIFF
--- a/ansible_catalog/main/inventory/task_utils/controller_config.py
+++ b/ansible_catalog/main/inventory/task_utils/controller_config.py
@@ -1,0 +1,14 @@
+""" Get Controller Config Information
+"""
+import dateutil.parser
+
+
+class ControllerConfig:
+    """ControllerConfig fetch controllers version"""
+
+    def __init__(self, tower):
+        self.tower = tower
+
+    def process(self):
+        for data in self.tower.get("/api/v2/config", ("version")):
+            return data

--- a/ansible_catalog/main/inventory/tests/task_utils/test_controller_config.py
+++ b/ansible_catalog/main/inventory/tests/task_utils/test_controller_config.py
@@ -1,0 +1,36 @@
+""" Test module for ControllerConfig  """
+from unittest.mock import Mock
+import pytest
+
+from ansible_catalog.main.inventory.task_utils.controller_config import (
+    ControllerConfig,
+)
+
+
+class TestControllerConfig:
+    """Test class for ControllerConfig."""
+
+    def fake_config(self, *_args, **_kwargs):
+        """Create a fake response object"""
+        objs = [
+            {
+                "time_zone": "UTC",
+                "version": "4.1.0",
+                "analytics_status": "off",
+            }
+        ]
+
+        for i in objs:
+            yield i
+
+    def test_controller_config(self):
+        """Test fetching controller config"""
+        tower_mock = Mock()
+        cc = ControllerConfig(tower_mock)
+        tower_mock.get.side_effect = self.fake_config
+        import pdb
+
+        pdb.set_trace()
+        response = cc.process()
+
+        assert (response["version"]) == "4.1.0"


### PR DESCRIPTION
Fetch the /api/v2/config from tower so we can know the Controllers
version.
THis information can be stored in the Source object and displayed
in the UI.

Part of https://issues.redhat.com/browse/SSP-2696