### PR TITLE
Remove Basic Authentication

### DIFF
--- a/ansible_catalog/common/auth/middleware.py
+++ b/ansible_catalog/common/auth/middleware.py
@@ -10,7 +10,9 @@ from social_django.models import UserSocialAuth
 from social_django.utils import load_strategy
 
 import requests
+import logging
 
+logger = logging.getLogger(__name__)
 
 KEYCLOAK_PROVIDER = "keycloak-oidc"
 
@@ -30,6 +32,7 @@ class KeycloakAuthMiddleware:
             request.keycloak_user = self._process_keycloak_user(request.user)
         except TokenRefreshError:
             # NOTE(cutwater): Not sure about correctness of this one
+            logger.debug("Token expired, sending back a 401")
             django_auth.logout(request)
             return HttpResponse(status=status.HTTP_401_UNAUTHORIZED)
         return self.get_response(request)

--- a/ansible_catalog/main/auth/tests/functional/test_me_endpoint.py
+++ b/ansible_catalog/main/auth/tests/functional/test_me_endpoint.py
@@ -27,7 +27,7 @@ def test_current_me_authenticated(api_request):
 
 @pytest.mark.django_db
 def test_current_me_unauthenticated(api_request):
-    """Unauthenticated user should return 401"""
+    """Unauthenticated user should return 403"""
     fred = User(
         username="fred",
         is_superuser=False,
@@ -38,4 +38,4 @@ def test_current_me_unauthenticated(api_request):
     fred.save()
     response = api_request("get", "me", None, None, fred, "json", False)
 
-    assert response.status_code == 401
+    assert response.status_code == 403

--- a/ansible_catalog/settings/defaults.py
+++ b/ansible_catalog/settings/defaults.py
@@ -116,7 +116,6 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 25,
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ),
     "DEFAULT_FILTER_BACKENDS": (


### PR DESCRIPTION
With Basic authentication enabled when we fail to refresh a token
from keycloak we send back a 401. The 401 response contains a header
WWW-Authenticate: Basic realm="api"

When the Web browser sees this header it pops up the Login dialog.
If we remove the Basic Authentication this header is not set.

https://issues.redhat.com/browse/SSP-2708