### PR TITLE
Add lock on source record when updating it in refresh task

### DIFF
--- a/automation_services_catalog/main/inventory/task_utils/refresh_inventory.py
+++ b/automation_services_catalog/main/inventory/task_utils/refresh_inventory.py
@@ -1,8 +1,9 @@
 """ Task to Refresh Inventory from the Tower """
 import logging
+from django.db import transaction
 from django.utils import timezone
 
-from automation_services_catalog.main.models import Source, Tenant
+from automation_services_catalog.main.models import Source
 from automation_services_catalog.main.inventory.task_utils.service_inventory_import import (
     ServiceInventoryImport,
 )
@@ -26,33 +27,39 @@ class RefreshInventory:
     """RefreshInventory imports objects from the tower"""
 
     # default constructor
-    def __init__(self, tenant_id, source_id):
+    def __init__(self, source_id):
         self.tower = TowerAPI()
-        self.source = Source.objects.get(pk=source_id)
-        self.tenant = Tenant.objects.get(pk=tenant_id)
+        self.source_id = source_id
 
-    # start processing
+    @transaction.atomic()
     def process(self):
-        self.source.refresh_started_at = timezone.now()
+        self.source = (
+            Source.objects.filter(pk=self.source_id)
+            .select_for_update(nowait=True)
+            .get()
+        )
 
+        self.source.refresh_started_at = timezone.now()
         try:
             """Run the import process"""
             spec_converter = SpecToDDF()
             plan_importer = ServicePlanImport(
-                self.tenant, self.source, self.tower, spec_converter
+                self.source.tenant, self.source, self.tower, spec_converter
             )
-            sii = ServiceInventoryImport(self.tenant, self.source, self.tower)
+            sii = ServiceInventoryImport(
+                self.source.tenant, self.source, self.tower
+            )
             logger.info("Fetching Inventory")
             sii.process()
 
             soi = ServiceOfferingImport(
-                self.tenant, self.source, self.tower, sii, plan_importer
+                self.source.tenant, self.source, self.tower, sii, plan_importer
             )
             logger.info("Fetching Job Templates & Workflows")
             soi.process()
 
             son = ServiceOfferingNodeImport(
-                self.tenant, self.source, self.tower, sii, soi
+                self.source.tenant, self.source, self.tower, sii, soi
             )
             logger.info("Fetching Workflow Template Nodes")
             son.process()

--- a/automation_services_catalog/main/inventory/tasks.py
+++ b/automation_services_catalog/main/inventory/tasks.py
@@ -30,12 +30,12 @@ def refresh_all_sources():
 def refresh_task(tenant_id, source_id):
     """Run the Refresh task"""
     logger.info("First checking its availability")
-    svc = CheckSourceAvailability(tenant_id, source_id)
+    svc = CheckSourceAvailability(source_id)
     svc.process()
 
     if svc.source.availability_status == "available":
         logger.info("Starting Inventory Refresh")
-        obj = RefreshInventory(tenant_id, source_id)
+        obj = RefreshInventory(source_id)
         obj.process()
         logger.info("Updating Service Plans")
         upd_sp = UpdateServicePlans(tenant_id)

--- a/automation_services_catalog/main/inventory/tests/task_utils/test_check_source_availability.py
+++ b/automation_services_catalog/main/inventory/tests/task_utils/test_check_source_availability.py
@@ -24,7 +24,7 @@ def test_process(mocker):
     )
     mocker.patch.object(ControllerConfig, "process", return_value=config)
 
-    svc = CheckSourceAvailability(tenant.id, source_instance.id)
+    svc = CheckSourceAvailability(source_instance.id)
     svc.process()
 
     source_instance.refresh_from_db()
@@ -50,7 +50,7 @@ def test_process_with_exception(mocker):
         side_effect=Exception("Failed to get controller config"),
     )
 
-    svc = CheckSourceAvailability(tenant.id, source_instance.id)
+    svc = CheckSourceAvailability(source_instance.id)
     svc.process()
 
     source_instance.refresh_from_db()

--- a/automation_services_catalog/main/inventory/tests/task_utils/test_refresh_inventory.py
+++ b/automation_services_catalog/main/inventory/tests/task_utils/test_refresh_inventory.py
@@ -29,7 +29,7 @@ class TestRefreshInventory:
         """Test the process method"""
         tenant = TenantFactory()
         source_instance = SourceFactory(tenant=tenant)
-        refresh_inventory = RefreshInventory(tenant.id, source_instance.id)
+        refresh_inventory = RefreshInventory(source_instance.id)
         refresh_inventory.process()
         assert (mock1.return_value.process.call_count) == 1
         assert (mock2.return_value.process.call_count) == 1
@@ -46,7 +46,7 @@ class TestRefreshInventory:
     def test_last_refresh_message(self, mocker):
         tenant = TenantFactory()
         source_instance = SourceFactory(tenant=tenant)
-        refresh_inventory = RefreshInventory(tenant.id, source_instance.id)
+        refresh_inventory = RefreshInventory(source_instance.id)
 
         mock1 = mock.Mock()
         mock2 = mock.Mock()
@@ -140,7 +140,7 @@ class TestRefreshInventory:
         tenant = TenantFactory()
         source_instance = SourceFactory(tenant=tenant)
 
-        refresh_inventory = RefreshInventory(tenant.id, source_instance.id)
+        refresh_inventory = RefreshInventory(source_instance.id)
         refresh_inventory.process()
 
         source_instance.refresh_from_db()


### PR DESCRIPTION
Use `select_for_update` to lock the source object to update it in refresh task.