### PR TITLE
Added support for kuberenetes job to do keycloak setup

### DIFF
--- a/tools/docker/scripts/keycloak-setup.sh
+++ b/tools/docker/scripts/keycloak-setup.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+set -e
 
 while true;
 do echo "Waiting for keycloak service to come up...";
-    wget http://keycloak-app:8080 -q -T 1 -O /dev/null >/dev/null 2>/dev/null && break;
+    wget $AUTOMATION_SERVICES_CATALOG_KEYCLOAK_URL -q -T 1 -O /dev/null >/dev/null 2>/dev/null && break;
     sleep 3;
 done;
 echo "Service is up!"

--- a/tools/minikube/scripts/server.sh
+++ b/tools/minikube/scripts/server.sh
@@ -19,9 +19,6 @@ then
 fi
 
 
-echo -e "\e[34m >>> Seed Kaycloak data \e[97m"
-ansible-playbook -vvv tools/keycloak_setup/dev.yml
-
 echo -e "\e[34m >>> Migrating changes \e[97m"
 python manage.py migrate
 echo -e "\e[32m >>> migration completed \e[97m"
@@ -39,5 +36,4 @@ echo -e "\e[34m >>> Collect static files \e[97m"
 python manage.py collectstatic
 
 echo -e "\e[34m >>> Start gunicorn server \e[97m"
-#python manage.py runserver 0.0.0.0:8000
 gunicorn --workers=3 --bind 0.0.0.0:8000 ansible_catalog.wsgi --log-level=debug

--- a/tools/minikube/scripts/start_pods.sh
+++ b/tools/minikube/scripts/start_pods.sh
@@ -56,6 +56,17 @@ kubectl apply --namespace=catalog -f ./tools/minikube/templates/postgres-deploym
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/postgres-service.yaml
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/keycloak-deployment.yaml
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/keycloak-service.yaml
+
+kubectl apply --namespace=catalog -f ./tools/minikube/templates/keycloak-setup.yml
+
+kubectl -n catalog wait --for=condition=complete --timeout=8m job/keycloak-setup
+
+if [ $? -ne 0 ]; then
+	echo "Could not wait for keycloak setup"
+	echo "run delete_pods.sh -d"
+	exit 1
+fi
+
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/app-claim0-persistentvolumeclaim.yaml
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/app-deployment.yaml
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/app-service.yaml

--- a/tools/minikube/templates/app-deployment.yaml
+++ b/tools/minikube/templates/app-deployment.yaml
@@ -39,14 +39,8 @@ spec:
               value: http://keycloak:8080/auth
             - name: AUTOMATION_SERVICES_CATALOG_KEYCLOAK_CLIENT_SECRET
               value: SOMESECRETVALUE
-            - name: AUTOMATION_SERVICES_CATALOG_KEYCLOAK_USER
-              value: admin
-            - name: AUTOMATION_SERVICES_CATALOG_KEYCLOAK_PASSWORD
-              value: admin
             - name: AUTOMATION_SERVICES_CATALOG_KEYCLOAK_REALM_FRONTEND_URL
               value: http://keycloak.k8s.local/auth
-            - name: REDIRECT_URIS_STR
-              value: http://app:8000,http://app:8000/*,*
             - name: CONTROLLER_VERIFY_SSL
               value: "False"
             - name: AUTOMATION_SERVICES_CATALOG_REDIS_HOST

--- a/tools/minikube/templates/keycloak-setup.yml
+++ b/tools/minikube/templates/keycloak-setup.yml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: keycloak-setup
+spec:
+  template:
+    spec:
+      containers:
+      - name: keycloak-setup
+        image: localhost/ansible-catalog
+        imagePullPolicy: Never
+        env:
+           - name: AUTOMATION_SERVICES_CATALOG_KEYCLOAK_URL
+             value: http://keycloak:8080/auth
+           - name: AUTOMATION_SERVICES_CATALOG_KEYCLOAK_CLIENT_SECRET
+             value: SOMESECRETVALUE
+           - name: AUTOMATION_SERVICES_CATALOG_KEYCLOAK_USER
+             value: admin
+           - name: AUTOMATION_SERVICES_CATALOG_KEYCLOAK_PASSWORD
+             value: admin
+           - name: AUTOMATION_SERVICES_CATALOG_KEYCLOAK_REALM_FRONTEND_URL
+             value: http://keycloak.k8s.local/auth
+           - name: REDIRECT_URIS_STR
+             value: http://app:8000,http://app:8000/*,*
+        command:  [/opt/app-root/src/tools/docker/scripts/keycloak-setup.sh]
+      restartPolicy: Never
+  backoffLimit: 1


### PR DESCRIPTION
For the minikube dev env we were running the keycloak setup everytime
we were doing redeployment of the app. It is unnecessary to do it
everytime it just needs to be done once. The app will start a lot
quicker now for developers as they test their changes. With this PR
we will run it once as a kubernetes job.