### PR TITLE
Fix docker-compose file version

### DIFF
--- a/tools/docker/docker-compose.override.yml
+++ b/tools/docker/docker-compose.override.yml
@@ -1,4 +1,5 @@
-version: '3'
+version: '3.9'
+
 x-environment:
   &catalog-env
   - AUTOMATION_SERVICES_CATALOG_CONTROLLER_TOKEN=${AUTOMATION_SERVICES_CATALOG_CONTROLLER_TOKEN}

--- a/tools/docker/docker-compose.stage.yml
+++ b/tools/docker/docker-compose.stage.yml
@@ -1,4 +1,5 @@
-version: '3'
+version: '3.9'
+
 x-environment:
   &catalog-env
   - AUTOMATION_SERVICES_CATALOG_CONTROLLER_TOKEN=${AUTOMATION_SERVICES_CATALOG_CONTROLLER_TOKEN}

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.9'
 
 services:
   frontend:


### PR DESCRIPTION
The `<service>.healthcheck.start_period` parameter is available
since the version `3.4` of docker-compose.yml specification.
The version `3` used in the project is too low.
Using the latest version `3.9`.