### PR TITLE
Remove deprecated `USE_L10N` parameter

### DIFF
--- a/automation_services_catalog/settings/defaults.py
+++ b/automation_services_catalog/settings/defaults.py
@@ -169,8 +169,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 


### PR DESCRIPTION
The `USE_L10N` setting is deprecated. Starting with Django 5.0,
localized formatting of data will always be enabled.
For example Django will display numbers and dates using the format
of the current locale.