### PR TITLE
Echo a message to the user using minikube dev env during keycloak setup

### DIFF
--- a/tools/minikube/scripts/start_pods.sh
+++ b/tools/minikube/scripts/start_pods.sh
@@ -59,6 +59,8 @@ kubectl apply --namespace=catalog -f ./tools/minikube/templates/keycloak-service
 
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/keycloak-setup.yml
 
+echo "We are adding roles, groups, users, permissions into Keycloak"
+echo "Waiting for Keycloak setup job to end, this could take a couple of minutes ....."
 kubectl -n catalog wait --for=condition=complete --timeout=8m job/keycloak-setup
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
The keycloak setup can take a couple of minutes, changed the script
to echo a message to the user about why its taking time.