### PR TITLE
Changed ansible-catalog to automation-services-catalog for Vagrant

### DIFF
--- a/tools/vagrant/catalog_install.sh
+++ b/tools/vagrant/catalog_install.sh
@@ -23,8 +23,8 @@ systemctl enable --now postgresql-13
 sudo -u postgres psql -c "ALTER USER $AUTOMATION_SERVICES_CATALOG_POSTGRES_USER PASSWORD '$AUTOMATION_SERVICES_CATALOG_POSTGRES_PASSWORD';"
 
 
-cp -R /src /opt/ansible-catalog
-cd /opt/ansible-catalog/
+cp -R /src /opt/automation-services-catalog
+cd /opt/automation-services-catalog/
 
 # In some of the dev env they might have their own venv which we should
 # delete from this vm 
@@ -35,7 +35,7 @@ fi
 
 export PATH="$PATH:/usr/pgsql-13/bin"
 python3 -m venv venv
-source /opt/ansible-catalog/venv/bin/activate
+source /opt/automation-services-catalog/venv/bin/activate
 pip3 install -U pip
 pip3 install -r requirements.txt
 
@@ -81,7 +81,7 @@ python3 /vagrant_data/scripts/apply_env.py /vagrant_data/catalog/services/catalo
 python3 /vagrant_data/scripts/apply_env.py /vagrant_data/catalog/services/catalog_worker.service.j2 /etc/systemd/system/catalog_worker.service
 
 adduser "$AUTOMATION_SERVICES_CATALOG_SERVICE_USER"
-chown "$AUTOMATION_SERVICES_CATALOG_SERVICE_USER"."$AUTOMATION_SERVICES_CATALOG_SERVICE_USER" -R /opt/ansible-catalog
+chown "$AUTOMATION_SERVICES_CATALOG_SERVICE_USER"."$AUTOMATION_SERVICES_CATALOG_SERVICE_USER" -R /opt/automation-services-catalog
 # Catalog should be able to write to the media directory
 chown "$AUTOMATION_SERVICES_CATALOG_SERVICE_USER"."$AUTOMATION_SERVICES_CATALOG_SERVICE_USER" -R $AUTOMATION_SERVICES_CATALOG_MEDIA_ROOT
 

--- a/tools/vagrant/data/catalog/services/catalog.service.j2
+++ b/tools/vagrant/data/catalog/services/catalog.service.j2
@@ -26,8 +26,8 @@ Environment=AUTOMATION_SERVICES_CATALOG_HTTPS_ENABLED={{AUTOMATION_SERVICES_CATA
 Environment=AUTOMATION_SERVICES_CATALOG_UI_ALLOWED_ORIGINS={{AUTOMATION_SERVICES_CATALOG_UI_ALLOWED_ORIGINS}}
 Environment=AUTOMATION_SERVICES_CATALOG_CSRF_TRUSTED_ORIGINS={{AUTOMATION_SERVICES_CATALOG_CSRF_TRUSTED_ORIGINS}}
 User={{AUTOMATION_SERVICES_CATALOG_SERVICE_USER}}
-WorkingDirectory=/opt/ansible-catalog
-ExecStart=/bin/bash -c 'cd /opt/ansible-catalog/ && source /opt/ansible-catalog/venv/bin/activate && gunicorn --workers=3 --bind 0.0.0.0:8000 automation_services_catalog.wsgi --log-level=debug'
+WorkingDirectory=/opt/automation-services-catalog
+ExecStart=/bin/bash -c 'cd /opt/automation-services-catalog/ && source /opt/automation-services-catalog/venv/bin/activate && gunicorn --workers=3 --bind 0.0.0.0:8000 automation_services_catalog.wsgi --log-level=debug'
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/vagrant/data/catalog/services/catalog_scheduler.service.j2
+++ b/tools/vagrant/data/catalog/services/catalog_scheduler.service.j2
@@ -26,8 +26,8 @@ Environment=AUTOMATION_SERVICES_CATALOG_HTTPS_ENABLED={{AUTOMATION_SERVICES_CATA
 Environment=AUTOMATION_SERVICES_CATALOG_UI_ALLOWED_ORIGINS={{AUTOMATION_SERVICES_CATALOG_UI_ALLOWED_ORIGINS}}
 Environment=AUTOMATION_SERVICES_CATALOG_CSRF_TRUSTED_ORIGINS={{AUTOMATION_SERVICES_CATALOG_CSRF_TRUSTED_ORIGINS}}
 User={{AUTOMATION_SERVICES_CATALOG_SERVICE_USER}}
-WorkingDirectory=/opt/ansible-catalog
-ExecStart=/bin/bash -c 'cd /opt/ansible-catalog/ && source /opt/ansible-catalog/venv/bin/activate && python manage.py cronjobs'
+WorkingDirectory=/opt/automation-services-catalog
+ExecStart=/bin/bash -c 'cd /opt/automation-services-catalog/ && source /opt/automation-services-catalog/venv/bin/activate && python manage.py cronjobs'
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/vagrant/data/catalog/services/catalog_worker.service.j2
+++ b/tools/vagrant/data/catalog/services/catalog_worker.service.j2
@@ -26,8 +26,8 @@ Environment=AUTOMATION_SERVICES_CATALOG_HTTPS_ENABLED={{AUTOMATION_SERVICES_CATA
 Environment=AUTOMATION_SERVICES_CATALOG_UI_ALLOWED_ORIGINS={{AUTOMATION_SERVICES_CATALOG_UI_ALLOWED_ORIGINS}}
 Environment=AUTOMATION_SERVICES_CATALOG_CSRF_TRUSTED_ORIGINS={{AUTOMATION_SERVICES_CATALOG_CSRF_TRUSTED_ORIGINS}}
 User={{AUTOMATION_SERVICES_CATALOG_SERVICE_USER}}
-WorkingDirectory=/opt/ansible-catalog
-ExecStart=/bin/bash -c 'cd /opt/ansible-catalog/ && source /opt/ansible-catalog/venv/bin/activate && python manage.py rqworker default'
+WorkingDirectory=/opt/automation-services-catalog
+ExecStart=/bin/bash -c 'cd /opt/automation-services-catalog/ && source /opt/automation-services-catalog/venv/bin/activate && python manage.py rqworker default'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The Vagrant VM installs the product into
/opt/automation-services-catalog