### PR TITLE
Update last_refresh_message when source is unavailable

### DIFF
--- a/automation_services_catalog/main/inventory/tasks.py
+++ b/automation_services_catalog/main/inventory/tasks.py
@@ -46,7 +46,9 @@ def refresh_task(tenant_id, source_id):
         logger.info("Finished Inventory Refresh")
     else:
         logger.error(
-            "Source %s is unavailable, cannot refresh it", svc.source.name
+            "Source %s[%s] is unavailable, cannot refresh it",
+            svc.source.name,
+            svc.tower.url,
         )
 
 


### PR DESCRIPTION
When source is unavailable, the `last_refresh_message` and `refresh_state` are updated as:

![image](https://user-images.githubusercontent.com/12900250/153644630-2848abae-a4c8-4c2a-b7ba-f90faeb08064.png)

https://issues.redhat.com/browse/SSP-2715