### PR TITLE
The sync groups tasks has moved to common from auth

### DIFF
--- a/automation_services_catalog/settings/defaults.py
+++ b/automation_services_catalog/settings/defaults.py
@@ -304,7 +304,7 @@ RQ_QUEUES = {
 
 # RQ Cron Jobs setting
 STARTUP_RQ_JOBS = [
-    "automation_services_catalog.main.auth.tasks.sync_external_groups",
+    "automation_services_catalog.main.common.tasks.sync_external_groups",
     "automation_services_catalog.main.inventory.tasks.refresh_all_sources",
 ]
 CRONTAB = env.str(
@@ -313,7 +313,7 @@ CRONTAB = env.str(
 RQ_CRONJOBS = [
     (
         CRONTAB,
-        "automation_services_catalog.main.auth.tasks.sync_external_groups",
+        "automation_services_catalog.main.common.tasks.sync_external_groups",
     ),
     (
         CRONTAB,


### PR DESCRIPTION
Leftover from this refactoring https://github.com/ansible/ansible-catalog/pull/320
There were no groups and during approval process creation the
UI was spinning because of 0 groups