### PR TITLE
Set SCHEMA_PATH_PREFIX to help auto tag endpoints

### DIFF
--- a/automation_services_catalog/main/auth/views.py
+++ b/automation_services_catalog/main/auth/views.py
@@ -22,6 +22,8 @@ from automation_services_catalog.common.auth.keycloak.openid import (
 @extend_schema_view(
     retrieve=extend_schema(
         description="Get the current login user",
+        tags=["auth"],
+        operation_id="me_retrieve",
     ),
 )
 class CurrentUserViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
@@ -33,6 +35,13 @@ class CurrentUserViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         return self.request.user
 
 
+@extend_schema_view(
+    post=extend_schema(
+        description="Logout current session",
+        tags=["auth"],
+        operation_id="logout_create",
+    ),
+)
 class SessionLogoutView(APIView):
     permission_classes = (IsAuthenticated,)
 

--- a/automation_services_catalog/settings/defaults.py
+++ b/automation_services_catalog/settings/defaults.py
@@ -324,7 +324,7 @@ RQ_CRONJOBS = [
 # Auto generation of openapi spec using Spectacular
 SPECTACULAR_SETTINGS = {
     "TITLE": "Catalog API",
-    "DESCRIPTION": "A set of APIs to create and manage Ansible catalogs and order from them.",
+    "DESCRIPTION": "A set of APIs to create and manage Automation Services Catalogs and order from them.",
     "VERSION": "0.1.0",
     "CONTACT": {
         "email": "support@redhat.com",
@@ -354,6 +354,7 @@ SPECTACULAR_SETTINGS = {
         },
     ],
     "COMPONENT_SPLIT_REQUEST": True,
+    "SCHEMA_PATH_PREFIX": "/{}/v1".format(CATALOG_API_PATH_PREFIX.strip("/")),
 }
 
 SOCIAL_AUTH_JSONFIELD_ENABLED = True


### PR DESCRIPTION
A follow-up for #321. Most endpoints were auto tagged with "api" in openapi.json. With this PR all endpoints now have the same tags as before #321.

FYI, currently openapi.json contains endpoints `/auth/logout` and `/auth/me`, but not `/auth/login`.