### PR TITLE
Add pk into good-names for .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -441,7 +441,8 @@ good-names=i,
            k,
            ex,
            Run,
-           _
+           _,
+           pk
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted


### PR DESCRIPTION
Since Django seems to use pk for primary key add it as a good variable