### PR TITLE
django-settings-module was not set in .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -37,6 +37,7 @@ limit-inference-results=100
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
 load-plugins=pylint_django
+django-settings-module=automation_services_catalog.settings.defaults
 
 # Pickle collected data for later comparisons.
 persistent=yes


### PR DESCRIPTION
Added django-settings-module
When we run pylint like pytest we need to set the following env var
export AUTOMATION_SERVICES_CATALOG_SECRET_KEY=<<KEY_VALUE>>

Fixes #349 