### PR TITLE
WIP: Testing Portfolio Permissions

### DIFF
--- a/pinakes/main/catalog/keycloak_backend.py
+++ b/pinakes/main/catalog/keycloak_backend.py
@@ -1,0 +1,80 @@
+"""Keycloak backend to fetch permissions"""
+import logging
+from django.contrib.auth.backends import ModelBackend
+from pinakes.common.auth.keycloak_django.clients import get_authz_client
+
+logger = logging.getLogger("catalog")
+
+
+class KeycloakBackend(ModelBackend):
+    def get_all_permissions(self, user_obj, obj=None):
+        _fetch_keycloak_permissions(user_obj)
+
+        if not user_obj.is_active or user_obj.is_anonymous:
+            return set()
+        if obj:
+            return _get_obj_permissions(
+                obj, user_obj._keycloak_authz_resources
+            )
+
+        return _get_all_permissions(user_obj._keycloak_authz_resources)
+
+
+def _fetch_keycloak_permissions(user):
+    if not hasattr(user, "_keycloak_authz_resources"):
+        logger.info("Fetching permissions from keycloak")
+        social = user.social_auth.get(provider="keycloak-oidc")
+        client = get_authz_client(social.extra_data["access_token"])
+        user._keycloak_authz_resources = client.get_permissions()
+        logger.info(user._keycloak_authz_resources)
+    else:
+        logger.info("Using cached keycloak resources")
+
+
+def _get_all_permissions(authz_resources):
+    permissions = set()
+    map_crud = {
+        "create": "%(app_label)s.add_%(model_name)s",
+        "read": "%(app_label)s.view_%(model_name)s",
+        "update": "%(app_label)s.change_%(model_name)s",
+        "write": "%(app_label)s.change_%(model_name)s",
+        "delete": "%(app_label)s.delete_%(model_name)s",
+        "order": "%(app_label)s.order_%(model_name)s",
+        "link": "%(app_label)s.change_%(model_name)s",
+        "unlink": "%(app_label)s.change_%(model_name)s",
+    }
+    kwargs = {"app_label": "main"}
+    for authz_res in authz_resources:
+        if authz_res.rsname.split(":").pop() == "all":
+            for scope in authz_res.scopes:
+                obj_scope = scope.split(":")
+                perm = obj_scope.pop()
+                kwargs["model_name"] = obj_scope.pop()
+                permissions.add(map_crud[perm] % kwargs)
+
+    return permissions
+
+
+def _get_obj_permissions(obj, authz_resources):
+    matching_names = []
+    map_crud = {}
+    if obj:
+        matching_names = [
+            f"{obj.__class__.KEYCLOAK_TYPE}:{obj.id}",
+            f"{obj.__class__.KEYCLOAK_TYPE}:all",
+        ]
+        klass_name = obj.__class__.__name__.lower()
+        map_crud = {
+            "create": f"main.add_{klass_name}",
+            "read": f"main.view_{klass_name}",
+            "update": f"main.change_{klass_name}",
+            "delete": f"main.delete_{klass_name}",
+            "order": f"main.order_{klass_name}",
+        }
+
+    permissions = set()
+    for authz_res in authz_resources:
+        if authz_res.rsname in matching_names:
+            for scope in authz_res.scopes:
+                permissions.add(map_crud[scope.split(":").pop()])
+    return permissions

--- a/pinakes/main/catalog/permissions.py
+++ b/pinakes/main/catalog/permissions.py
@@ -1,54 +1,108 @@
 """PortfolioPermission Module"""
+import json
 import logging
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.permissions import DjangoModelPermissions
-from pinakes.common.auth.keycloak_django.permissions import (
-    check_wildcard_permission,
-    get_permitted_resources,
-)
-from pinakes.common.auth.keycloak_django.clients import get_authz_client
+from pinakes.main.catalog.models import Portfolio
 
 logger = logging.getLogger("catalog")
 
 
 class PortfolioPermissions(DjangoModelPermissions):
-    """
-    The request is authenticated using Django's object-level permissions.
-    It requires an object-permissions-enabled backend, such as Django Guardian.
-    It ensures that the user is authenticated, and has the appropriate
-    `add`/`change`/`delete` permissions on the object using .has_perms.
-    This permission can only be applied against view classes that
-    provide a `.queryset` attribute.
-    """
-
     perms_map = {
-        "list": ["read"],
-        "retrieve": ["read"],
-        "create": ["create"],
-        "update": ["update"],
-        "partial_update": ["update"],
-        "destroy": ["delete"],
+        "list": ["%(app_label)s.view_%(model_name)s"],
+        "retrieve": ["%(app_label)s.view_%(model_name)s"],
+        "create": ["%(app_label)s.add_%(model_name)s"],
+        "update": ["%(app_label)s.change_%(model_name)s"],
+        "partial_update": ["%(app_label)s.change_%(model_name)s"],
+        "destroy": ["%(app_label)s.delete_%(model_name)s"],
         # Custom actions
         # Icons
-        "icon": ["update"],
+        "icon": ["%(app_label)s.change_%(model_name)s"],
         # Tags
-        "tags": ["read"],
-        "tag": ["update"],
-        "untag": ["update"],
+        "tags": ["%(app_label)s.view_%(model_name)s"],
+        "tag": ["%(app_label)s.change_%(model_name)s"],
+        "untag": ["%(app_label)s.change_%(model_name)s"],
         # Sharing
-        "share": ["update"],
-        "unshare": ["update"],
-        "share_info": ["update"],
-        # Copy
-        "copy": ["create", "read"],
+        "share": ["%(app_label)s.change_%(model_name)s"],
+        "unshare": ["%(app_label)s.change_%(model_name)s"],
+        "share_info": ["%(app_label)s.change_%(model_name)s"],
+        "copy": [
+            "%(app_label)s.view_%(model_name)s",
+            "%(app_label)s.add_%(model_name)s",
+        ],
     }
 
-    def get_required_object_permissions(self, action, _model_cls):
+    def get_required_object_permissions(self, action, model_cls):
         """Get the required permissions based on the  current action"""
+        kwargs = {
+            "app_label": model_cls._meta.app_label,
+            "model_name": model_cls._meta.model_name,
+        }
         if action not in self.perms_map:
             raise MethodNotAllowed(action)
+        return [perm % kwargs for perm in self.perms_map[action]]
 
-        return self.perms_map[action]
+    def has_permission(self, request, view):
+        # Workaround to ensure DjangoModelPermissions are not applied
+        # to the root view when using DefaultRouter.
+        if getattr(view, "_ignore_model_permissions", False):
+            return True
+
+        if not request.user or (
+            not request.user.is_authenticated and self.authenticated_users_only
+        ):
+            return False
+        queryset = self._queryset(view)
+        perms = self.get_required_permissions(view.action, queryset.model)
+        request.user.get_all_permissions()
+
+        if view.action == "create":
+            return request.user.has_perm(perms[0])
+
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        """Check a single objects permission"""
+        queryset = self._queryset(view)
+        model_cls = queryset.model
+        _clear_perm_cache(request.user)
+        request.user.get_all_permissions(obj)
+
+        perms = self.get_required_object_permissions(view.action, model_cls)
+        return request.user.has_perm(perms[0], obj)
+
+
+class PortfolioItemPermissions(DjangoModelPermissions):
+    perms_map = {
+        "list": ["%(app_label)s.view_%(model_name)s"],
+        "retrieve": ["%(app_label)s.view_%(model_name)s"],
+        "create": ["%(app_label)s.change_%(model_name)s"],
+        "update": ["%(app_label)s.change_%(model_name)s"],
+        "partial_update": ["%(app_label)s.change_%(model_name)s"],
+        "destroy": ["%(app_label)s.change_%(model_name)s"],
+        # Custom actions
+        # Icons
+        "icon": ["%(app_label)s.change_%(model_name)s"],
+        # Tags
+        "tags": ["%(app_label)s.view_%(model_name)s"],
+        "tag": ["%(app_label)s.change_%(model_name)s"],
+        "untag": ["%(app_label)s.change_%(model_name)s"],
+        "copy": [
+            "%(app_label)s.view_%(model_name)s",
+            "%(app_label)s.change_%(model_name)s",
+        ],
+    }
+
+    def get_required_object_permissions(self, action, model_cls):
+        """Get the required permissions based on the  current action"""
+        kwargs = {
+            "app_label": model_cls._meta.app_label,
+            "model_name": model_cls._meta.model_name,
+        }
+        if action not in self.perms_map:
+            raise MethodNotAllowed(action)
+        return [perm % kwargs for perm in self.perms_map[action]]
 
     def has_permission(self, request, view):
         # Workaround to ensure DjangoModelPermissions are not applied
@@ -61,33 +115,81 @@ class PortfolioPermissions(DjangoModelPermissions):
         ):
             return False
 
+        model_cls = Portfolio
+        perms = self.get_required_permissions(view.action, model_cls)
+        request.user.get_all_permissions()
+
         if view.action == "create":
-            social = request.user.social_auth.get(provider="keycloak-oidc")
-            client = get_authz_client(social.extra_data["access_token"])
-            return check_wildcard_permission(
-                "catalog:portfolio", "create", client
-            )
+            logger.info(request.data)
+            if "portfolio" in request.data:
+                obj = Portfolio.objects.get(pk=request.data["portfolio"])
+                logger.info(obj)
+                return request.user.has_perm(perms[0], obj)
 
         return True
 
     def has_object_permission(self, request, view, obj):
         """Check a single objects permission"""
-        queryset = self._queryset(view)
-        model_cls = queryset.model
-        user = request.user
+        model_cls = Portfolio
+        _clear_perm_cache(request.user)
+        logger.info("Get single object permission")
+        logger.info(obj.portfolio.name)
+        kperms = request.user.get_all_permissions(obj.portfolio)
+        logger.info(kperms)
 
+        logger.info("Required object permission")
         perms = self.get_required_object_permissions(view.action, model_cls)
-        result = get_keycloak_result(user, perms[0], model_cls)
-        if result.is_wildcard or str(obj.id) in result.items:
+        logger.info(perms)
+
+        return request.user.has_perm(perms[0], obj.portfolio)
+
+class ServicePlanPermissions(DjangoModelPermissions):
+    """ServicePlanPermission is controlled by the Portfolio Object"""
+    perms_map = {
+        "retrieve": ["%(app_label)s.view_%(model_name)s"],
+        "reset": ["%(app_label)s.change_%(model_name)s"],
+        "partial_update": ["%(app_label)s.change_%(model_name)s"],
+    }
+
+    def get_required_object_permissions(self, action, model_cls):
+        """Get the required permissions based on the  current action"""
+        kwargs = {
+            "app_label": model_cls._meta.app_label,
+            "model_name": model_cls._meta.model_name,
+        }
+        if action not in self.perms_map:
+            raise MethodNotAllowed(action)
+        return [perm % kwargs for perm in self.perms_map[action]]
+
+    def has_permission(self, request, view):
+        # Workaround to ensure DjangoModelPermissions are not applied
+        # to the root view when using DefaultRouter.
+        if getattr(view, "_ignore_model_permissions", False):
             return True
 
-        return False
+        if not request.user or (
+            not request.user.is_authenticated and self.authenticated_users_only
+        ):
+            return False
+
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        """Check a single objects permission"""
+        model_cls = Portfolio
+        portfolio = obj.portfolio_item.portfolio
+        _clear_perm_cache(request.user)
+        kperms =request.user.get_all_permissions(portfolio)
+        logger.info("Service Plan")
+        logger.info(kperms)
+
+        perms = self.get_required_object_permissions(view.action, model_cls)
+        logger.info("Required Service Plan")
+        logger.info(perms)
+        return request.user.has_perm(perms[0], portfolio)
 
 
-def get_keycloak_result(user, requested_perm, model_cls):
-    """Get the permissions from keycloak"""
-    social = user.social_auth.get(provider="keycloak-oidc")
-    client = get_authz_client(social.extra_data["access_token"])
-    return get_permitted_resources(
-        model_cls.KEYCLOAK_TYPE, requested_perm, client
-    )
+def _clear_perm_cache(user):
+    for attr in ("_perm_cache", "_user_perm_cache", "_group_perm_cache"):
+        if hasattr(user, attr):
+            delattr(user, attr)

--- a/pinakes/main/catalog/user_capabilities.py
+++ b/pinakes/main/catalog/user_capabilities.py
@@ -1,0 +1,79 @@
+"""User Capabilities"""
+import logging
+
+logger = logging.getLogger("catalog")
+
+
+class UserCapabilities:
+    """Collect User Capabilities based on permission sets
+    defined in a dict
+    """
+
+    capabilities_map = {}
+
+    def __init__(self, user, obj):
+        self.user = user
+        self.obj = obj
+
+    def get(self):
+        """Get the user capabilties for the specified object"""
+        kwargs = {
+            "app_label": self.obj.__class__._meta.app_label,
+            "model_name": self.obj.__class__._meta.model_name,
+        }
+        assigned_permissions = self.user.get_all_permissions(self.obj)
+        capabilities = {}
+        status = {}
+        for key, required_perms in self.capabilities_map.items():
+            for perm in required_perms:
+                if perm in status:
+                    result = status[perm]
+                else:
+                    status[perm] = perm % kwargs in assigned_permissions
+                    result = status[perm]
+
+                if not result:
+                    capabilities[key] = False
+                    break
+
+                capabilities[key] = True
+        return capabilities
+
+
+class PortfolioUserCapabilities(UserCapabilities):
+    """User capabilities for Portfolio objects"""
+
+    capabilities_map = {
+        "create": ["%(app_label)s.add_%(model_name)s"],
+        "update": ["%(app_label)s.change_%(model_name)s"],
+        "destroy": ["%(app_label)s.delete_%(model_name)s"],
+        "copy": [
+            "%(app_label)s.view_%(model_name)s",
+            "%(app_label)s.add_%(model_name)s",
+        ],
+        "share": ["%(app_label)s.change_%(model_name)s"],
+        "unshare": ["%(app_label)s.change_%(model_name)s"],
+        "show": ["%(app_label)s.view_%(model_name)s"],
+        "set_approval": ["%(app_label)s.change_%(model_name)s"],
+        "tag": ["%(app_label)s.change_%(model_name)s"],
+        "untag": ["%(app_label)s.change_%(model_name)s"],
+    }
+
+
+class PortfolioItemUserCapabilities(UserCapabilities):
+    """User capabilities for PortfolioItem objects"""
+
+    capabilities_map = {
+        "create": ["%(app_label)s.change_%(model_name)s"],
+        "update": ["%(app_label)s.change_%(model_name)s"],
+        "destroy": ["%(app_label)s.change_%(model_name)s"],
+        "copy": [
+            "%(app_label)s.view_%(model_name)s",
+            "%(app_label)s.change_%(model_name)s",
+        ],
+        "show": ["%(app_label)s.view_%(model_name)s"],
+        "set_approval": ["%(app_label)s.change_%(model_name)s"],
+        "edit_survey": ["%(app_label)s.change_%(model_name)s"],
+        "tag": ["%(app_label)s.change_%(model_name)s"],
+        "untag": ["%(app_label)s.change_%(model_name)s"],
+    }

--- a/pinakes/main/catalog/views.py
+++ b/pinakes/main/catalog/views.py
@@ -85,6 +85,8 @@ from pinakes.main.catalog.services.validate_order_item import (
 )
 from pinakes.main.catalog.permissions import (
     PortfolioPermissions,
+    PortfolioItemPermissions,
+    ServicePlanPermissions,
 )
 
 from pinakes.main.catalog import tasks
@@ -317,7 +319,7 @@ class PortfolioItemViewSet(
 
     serializer_class = PortfolioItemSerializer
     http_method_names = ["get", "post", "head", "patch", "delete"]
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, PortfolioItemPermissions)
     ordering = ("-id",)
     filterset_fields = (
         "name",

--- a/pinakes/settings/defaults.py
+++ b/pinakes/settings/defaults.py
@@ -147,7 +147,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTHENTICATION_BACKENDS = [
     "pinakes.common.auth.keycloak_oidc.KeycloakOpenIdConnect",
-    "django.contrib.auth.backends.ModelBackend",
+    "pinakes.main.catalog.keycloak_backend.KeycloakBackend",
 ]
 
 # Internationalization


### PR DESCRIPTION
This PR implements a working prototype based on ModelBackend.
It creates a backend called KeycloakBackend.
https://docs.djangoproject.com/en/4.0/topics/auth/customizing/#handling-authorization-in-custom-backends

Django documentation on custom
authorization recommends implementing a get_all_permissions
object in the backend that can talk to your custom backend and
fetch all the permissions for the request and cache it.
Once the permissions are available they can be called from
the has_permission and has_object_permission methods defined
in a permission class.

The model permission classes like PortfolioPermissions and 
PortfolioItemPermissions inherit from the DjangoModelPermissions.
They add the has_permission and has_object_permission

It also implements the user_capabilities
```
{
            "id": 10,
            "name": "Marketing1",
            "description": "",
            "metadata": {
                "statistics": {
                    "approval_processes": 0,
                    "portfolio_items": 2,
                    "shared_groups": 2
                },
                "user_capabilities": {
                    "create": false,
                    "update": true,
                    "destroy": false,
                    "copy": false,
                    "share": true,
                    "unshare": true,
                    "show": true,
                    "set_approval": true,
                    "tag": true,
                    "untag": true
                }
            },
            "owner": "Fred Sample",
            "icon_url": null,
            "created_at": "2022-02-25T19:23:55.962641Z",
            "updated_at": "2022-02-25T19:25:31.024646Z"
        },
```

This will allow us to cache permissions in the user object temporarily and allow us to use
has_permission on an object with cached permissions.





