### PR TITLE
Fix development settings file to use SQLite DB

### DIFF
--- a/pinakes/settings/development.py
+++ b/pinakes/settings/development.py
@@ -21,13 +21,13 @@ except ImportError:
     sys.exit(1)
 
 # Use SQLite for unit tests instead of PostgreSQL
-if "pytest" in sys.modules:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": BASE_DIR / "catalog_test.db",
-        },
-    }
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "catalog_test.db",
+    },
+}
 
 ALLOWED_HOSTS = ["*"]
 CONTROLLER_VERIFY_SSL = "False"


### PR DESCRIPTION
Previously only pytest uses SQLite now we can use the
same SQLite DB for local dev environment. It helps in
creating migrations without using Postgres for local
development. When running the full suite in minikube we still
use Postgres.