### PR TITLE
Clear Share information when copying portfolio

### DIFF
--- a/pinakes/main/catalog/services/copy_portfolio.py
+++ b/pinakes/main/catalog/services/copy_portfolio.py
@@ -31,12 +31,14 @@ class CopyPortfolio:
         self.new_portfolio = None
 
     def process(self):
+        """Start copy proces."""
         self.make_copy()
 
         return self
 
     @transaction.atomic
     def make_copy(self):
+        """Make a copy of the Portfolio."""
         new_icon = (
             CopyImage(self.portfolio.icon).process().new_icon
             if self.portfolio.icon
@@ -45,6 +47,8 @@ class CopyPortfolio:
 
         self.new_portfolio = copy.copy(self.portfolio)
         self.new_portfolio.id = None
+        self.new_portfolio.keycloak_id = None
+        self.new_portfolio.share_count = 0
         self.new_portfolio.name = self._new_portfolio_name()
         self.new_portfolio.icon = new_icon
         self.new_portfolio.save()

--- a/pinakes/main/catalog/tests/services/test_copy_portfolio.py
+++ b/pinakes/main/catalog/tests/services/test_copy_portfolio.py
@@ -21,7 +21,8 @@ from pinakes.main.catalog.tests.factories import (
 
 @pytest.mark.django_db
 def test_portfolio_copy():
-    portfolio = PortfolioFactory()
+    """Copy a portfolio without portfolio items."""
+    portfolio = PortfolioFactory(share_count=10, keycloak_id="gobbledegook")
     options = {
         "portfolio_name": "my test",
     }
@@ -31,10 +32,13 @@ def test_portfolio_copy():
 
     assert Portfolio.objects.count() == 2
     assert svc.new_portfolio.name == "my test"
+    assert svc.new_portfolio.keycloak_id is None
+    assert svc.new_portfolio.share_count == 0
 
 
 @pytest.mark.django_db
 def test_portfolio_copy_with_portfolio_items():
+    """Copy a portfolio with portfolio items."""
     portfolio = PortfolioFactory()
     PortfolioItemFactory(portfolio=portfolio)
 
@@ -57,6 +61,7 @@ def test_portfolio_copy_with_portfolio_items():
 
 @pytest.mark.django_db
 def test_portfolio_copy_with_icon():
+    """Copy a portfolio with icon."""
     image = ImageFactory()
     portfolio = PortfolioFactory(icon=image)
 


### PR DESCRIPTION
Clear the keycloak_id and share_count in the newly copied
portfolo.
Added docs for methods

https://issues.redhat.com/browse/SSP-2757


<img width="697" alt="Screen Shot 2022-03-01 at 4 13 59 PM" src="https://user-images.githubusercontent.com/6452699/156249957-71592fd7-9580-44f2-b523-551dc92e2b01.png">
7