### PR TITLE
Prevent too many DB calls because of swagger

### DIFF
--- a/pinakes/common/queryset_mixin.py
+++ b/pinakes/common/queryset_mixin.py
@@ -16,6 +16,11 @@ class QuerySetMixin:
         parent_field_names = getattr(self, "parent_field_names", [])
         queryset_order_by = getattr(self, "queryset_order_by", None)
         serializer_class = self.get_serializer_class() or self.serializer_class
+
+        # If this is swagger return back the empty qs
+        if getattr(self, "swagger_fake_view", False):
+            return serializer_class.Meta.model.objects.none()
+
         queryset = serializer_class.Meta.model.objects.filter(
             tenant=Tenant.current()
         )


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2769

Intercept the swagger call to get_queryset and return the none queryset for the model.
A better solution would be have a static openapi.json so we dont have to
have swagger regenerate the openapi.json everytime the UI calls
GET /api/pinakes/v1/schema/openapi.json

Log of the DB calls is attached in the JIRA ticket

https://issues.redhat.com/browse/SSP-2769