### PR TITLE
PermissionQuerySetMixin: return earilier when view is for swagger

### DIFF
--- a/pinakes/common/auth/keycloak_django/views.py
+++ b/pinakes/common/auth/keycloak_django/views.py
@@ -13,6 +13,9 @@ ScopeQuerysetFn = Callable[[Request, APIView, QuerySet], QuerySet]
 class PermissionQuerySetMixin:
     def get_queryset(self) -> QuerySet:
         qs = super().get_queryset()
+        swagger_view = getattr(self, "swagger_fake_view", False)
+        if swagger_view:
+            return qs
         for permission in self.get_permissions():
             scope_queryset_fn: ScopeQuerysetFn = getattr(
                 permission, "scope_queryset", None

--- a/pinakes/main/approval/views.py
+++ b/pinakes/main/approval/views.py
@@ -76,7 +76,7 @@ class TemplateViewSet(
     http_method_names = ["get", "post", "patch", "delete"]
     permission_classes = (IsAuthenticated,)
     serializer_class = TemplateSerializer
-    ordering_fields = "__all__"  # This line is optional, default
+    ordering_fields = ("title", "description")
     ordering = ("-id",)
     search_fields = ("title", "description")
 
@@ -268,7 +268,7 @@ class RequestViewSet(
     serializer_class = RequestSerializer
     http_method_names = ["get", "post"]
     ordering = ("-id",)
-    filterset_fields = "__all__"
+    filterset_fields = ("name", "description", "state", "decision", "reason")
     search_fields = ("name", "description", "state", "decision", "reason")
     parent_field_names = ("parent",)
 
@@ -345,7 +345,7 @@ class ActionViewSet(QuerySetMixin, viewsets.ModelViewSet):
     http_method_names = ["get", "post"]
     permission_classes = (IsAuthenticated,)
     ordering = ("-id",)
-    filterset_fields = "__all__"
+    filterset_fields = ("operation", "comments")
     search_fields = ("operation", "comments")
     parent_field_names = ("request",)
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2766

The filter function still works. The problem is that drf-spectacular failed to add attributes to filtering list. The fix follows https://github.com/tfranzel/drf-spectacular/blob/master/drf_spectacular/plumbing.py#L174

Also restrict the filterable fields to an explicit list for views. 