### PR TITLE
Changed to verbose logging which include process/thread id

### DIFF
--- a/pinakes/settings/defaults.py
+++ b/pinakes/settings/defaults.py
@@ -208,7 +208,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "verbose": {
-            "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
+            "format": "[{asctime}] [{process:d}] [{levelname}] {module} {thread:d} {message}",
             "style": "{",
         },
         "simple": {
@@ -227,7 +227,7 @@ LOGGING = {
         "console": {
             "level": LOG_LEVEL,
             "class": "logging.StreamHandler",
-            "formatter": "simple",
+            "formatter": "verbose",
         },
         "rq_console": {
             "level": LOG_LEVEL,


### PR DESCRIPTION
Since we log to console multiple gunicorn processes log messages
get interspersed, the verbose formatter logs the process id.

```
app-57bb9657b6-vxkhn app [2022-03-03 20:30:34 +0000] [23] [DEBUG] GET /api/pinakes/auth/me/
app-57bb9657b6-vxkhn app [2022-03-03 20:30:35 +0000] [25] [DEBUG] GET /api/pinakes/v1/portfolios/
app-57bb9657b6-vxkhn app [2022-03-03 20:30:35 +0000] [23] [DEBUG] GET /api/pinakes/auth/me/
app-57bb9657b6-vxkhn app [2022-03-03 20:30:35,835] [25] [INFO] permissions 140674534781184 Starting get_permitted_resources
app-57bb9657b6-vxkhn app [2022-03-03 20:30:52,514] [25] [INFO] permissions 140674534781184 Finished get_permitted_resources
```