### PR TITLE
Set verify_aud to False

### DIFF
--- a/pinakes/main/auth/serializers.py
+++ b/pinakes/main/auth/serializers.py
@@ -23,7 +23,8 @@ class CurrentUserSerializer(serializers.ModelSerializer):
         request = self.context.get("request")
         extra_data = request.keycloak_user.extra_data
         jot = jwt.decode(
-            extra_data["access_token"], options={"verify_signature": False}
+            extra_data["access_token"],
+            options={"verify_signature": False, "verify_aud": False},
         )
         roles = (
             jot.get("resource_access", {})


### PR DESCRIPTION
When using older versions of PyJWT we might have to explicitly set
verify_aud to False otherwise it leads to the following error when
decoding the token.
jwt.exceptions.InvalidAudienceError: Invalid audience