### PR TITLE
Refactor `start_pods.sh`

### DIFF
--- a/tools/minikube/scripts/start_pods.sh
+++ b/tools/minikube/scripts/start_pods.sh
@@ -1,54 +1,57 @@
-#!/bin/sh
+#!/bin/bash
 # For development purpose only
 # Set the environment variable for accessing your Automation Controller
 # export PINAKES_CONTROLLER_URL=<<your controller url>>
 # export PINAKES_CONTROLLER_TOKEN=<<your controller token>>
 # export PINAKES_CONTROLLER_VERIFY_SSL=True|False
 
-if [[ -z "${PINAKES_CONTROLLER_URL}" ]]
-then
-  echo "Please set the environment variable PINAKES_CONTROLLER_URL"
-  exit 1
+set -o nounset
+set -o errexit
+
+PINAKES_CONTROLLER_URL=${PINAKES_CONTROLLER_URL:-}
+PINAKES_CONTROLLER_TOKEN=${PINAKES_CONTROLLER_TOKEN:-}
+PINAKES_CONTROLLER_VERIFY_SSL=${PINAKES_CONTROLLER_VERIFY_SSL:-}
+
+if [[ -z "${PINAKES_CONTROLLER_URL}" ]]; then
+  echo "Warning: PINAKES_CONTROLLER_URL is not set."
 fi
 
-if [[ -z "${PINAKES_CONTROLLER_TOKEN}" ]]
-then
-  echo "Please set the environment variable PINAKES_CONTROLLER_TOKEN"
-  exit 1
+if [[ -z "${PINAKES_CONTROLLER_TOKEN}" ]]; then
+  echo "Warning: PINAKES_CONTROLLER_TOKEN is not set."
 fi
 
-if [[ -z "${PINAKES_CONTROLLER_VERIFY_SSL}" ]]
-then
-  echo "Please set the environment variable PINAKES_CONTROLLER_VERIFY_SSL"
-  exit 1
+if [[ -z "${PINAKES_CONTROLLER_VERIFY_SSL}" ]]; then
+  echo "Warning: PINAKES_CONTROLLER_VERIFY_SSL is not set."
 fi
 
-kubectl get namespace catalog 2>> /dev/null
-if [ $? -ne 0 ]; then
+if ! kubectl get namespace catalog &>/dev/null; then
 	kubectl create namespace catalog
 fi
 
-kubectl get configmap --namespace=catalog dbscripts 2>> /dev/null
-if [ $? -ne 0 ]; then
+if ! kubectl get configmap --namespace=catalog dbscripts &>/dev/null; then
 	kubectl create --namespace=catalog configmap dbscripts --from-file=./tools/minikube/templates/scripts
 fi
 
-kubectl get configmap --namespace=catalog catalog-nginx.conf 2>> /dev/null
-if [ $? -ne 0 ]; then
+if ! kubectl get configmap --namespace=catalog catalog-nginx.conf &>/dev/null; then
 	kubectl create --namespace=catalog configmap catalog-nginx.conf --from-file=./tools/minikube/nginx
 fi
 
-kubectl get configmap --namespace=catalog ssl 2>> /dev/null
-if [ $? -ne 0 ]; then
-	kubectl create --namespace=catalog configmap ssl --from-file=./tools/minikube/nginx/catalog.k8s.local.key --from-file=./tools/minikube/nginx/catalog.k8s.local.crt
+if ! kubectl get configmap --namespace=catalog ssl &>/dev/null; then
+	kubectl create --namespace=catalog configmap ssl \
+        --from-file='./tools/minikube/nginx/catalog.k8s.local.key' \
+        --from-file='./tools/minikube/nginx/catalog.k8s.local.crt'
 fi
 
-kubectl get configmap --namespace=catalog ansible-controller-env 2>> /dev/null
-if [ $? -eq 0 ]; then
+if kubectl get configmap --namespace=catalog ansible-controller-env &>/dev/null; then
 	kubectl delete --namespace=catalog configmap ansible-controller-env
 fi
 
-kubectl create configmap --namespace=catalog ansible-controller-env --from-literal=PINAKES_CONTROLLER_URL="$PINAKES_CONTROLLER_URL" --from-literal=PINAKES_CONTROLLER_TOKEN="$PINAKES_CONTROLLER_TOKEN" --from-literal=PINAKES_CONTROLLER_VERIFY_SSL="$PINAKES_CONTROLLER_VERIFY_SSL"
+kubectl create configmap \
+    --namespace=catalog \
+    ansible-controller-env \
+    --from-literal=PINAKES_CONTROLLER_URL="$PINAKES_CONTROLLER_URL" \
+    --from-literal=PINAKES_CONTROLLER_TOKEN="$PINAKES_CONTROLLER_TOKEN" \
+    --from-literal=PINAKES_CONTROLLER_VERIFY_SSL="$PINAKES_CONTROLLER_VERIFY_SSL"
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/redis-deployment.yaml
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/redis-service.yaml
 kubectl apply --namespace=catalog -f ./tools/minikube/templates/pg-data-persistentvolumeclaim.yaml
@@ -61,9 +64,7 @@ kubectl apply --namespace=catalog -f ./tools/minikube/templates/keycloak-setup.y
 
 echo "We are adding roles, groups, users, permissions into Keycloak"
 echo "Waiting for Keycloak setup job to end, this could take a couple of minutes ....."
-kubectl -n catalog wait --for=condition=complete --timeout=8m job/keycloak-setup
-
-if [ $? -ne 0 ]; then
+if ! kubectl -n catalog wait --for=condition=complete --timeout=8m job/keycloak-setup; then
 	echo "Could not wait for keycloak setup"
 	echo "run delete_pods.sh -d"
 	exit 1


### PR DESCRIPTION
* Make script parameters (passed as environment variables) optional.

* Use `#!/bin/bash` instead of `#!/bin/sh` due to bash syntax usage in
  the script (`[[ ]]`).
  Shellcheck: `SC3010 (warning): In POSIX sh, [[ ]] is undefined.`
* Check exit code directly instead of using temporary variable.
  Shellcheck: `SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not
  indirectly with $?.`
* Add `errexit`, `nounset` execution options.