### PR TITLE
Force HTTPS for Keycloak in minikube environment

### DIFF
--- a/tools/minikube/templates/ingress.yaml
+++ b/tools/minikube/templates/ingress.yaml
@@ -7,6 +7,9 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
+  tls:
+    - hosts:
+        - "keycloak.k8s.local"
   rules:
     - host: "keycloak.k8s.local"
       http:
@@ -30,6 +33,9 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/secure-backends: "true"
 spec:
+  tls:
+    - hosts:
+        - "catalog.k8s.local"
   rules:
     - host: "catalog.k8s.local"
       http:

--- a/tools/minikube/templates/keycloak-deployment.yaml
+++ b/tools/minikube/templates/keycloak-deployment.yaml
@@ -39,6 +39,7 @@ spec:
               value: admin
             - name: KEYCLOAK_USER
               value: admin
+          args: ['-Dkeycloak.frontendUrl=https://keycloak.k8s.local/auth']
           image: quay.io/keycloak/keycloak:15.0.2
           name: keycloak
           ports:


### PR DESCRIPTION
* This setting will enable 308 redirect on all `http` requests to `https:
```
  tls:
    - hosts:
        - "keycloak.k8s.local"
```

* The keycloak parameter `-Dkeycloak.frontendUrl=https://keycloak.k8s.local/auth` prevents endless redirect loop when trying to access the Keycloak's admin site.

Depends-On: #401 