### PR TITLE
Loosen instance check in BaseKeycloakPermission class

### DIFF
--- a/pinakes/common/auth/keycloak_django/permissions.py
+++ b/pinakes/common/auth/keycloak_django/permissions.py
@@ -26,9 +26,7 @@ from pinakes.common.auth.keycloak import (
     models as keycloak_models,
 )
 from pinakes.common.auth.keycloak.authz import AuthzClient
-from pinakes.common.auth.keycloak_django import (
-    AbstractKeycloakResource,
-)
+from pinakes.common.auth.keycloak_django.models import KeycloakMixin
 from pinakes.common.auth.keycloak_django.utils import (
     make_scope_name,
     make_resource_name,
@@ -123,7 +121,7 @@ class BaseKeycloakPermission(_BasePermission):
         return self.perform_check_permission(permission, request, view)
 
     def has_object_permission(
-        self, request: Request, view: Any, obj: models.Model
+        self, request: Request, view: Any, obj: Any
     ) -> bool:
         permission = self.get_required_permission(
             KeycloakPolicy.Type.OBJECT, request, view
@@ -135,7 +133,7 @@ class BaseKeycloakPermission(_BasePermission):
         # to has_object_permission method, additional checks are required.
         # See https://github.com/encode/django-rest-framework/issues/2089
         # for more details.
-        if not isinstance(obj, AbstractKeycloakResource):
+        if not isinstance(obj, KeycloakMixin):
             return False
         return self.perform_check_object_permission(
             permission, request, view, obj
@@ -164,7 +162,7 @@ class BaseKeycloakPermission(_BasePermission):
         permission: str,
         request: Request,
         view: Any,
-        obj: AbstractKeycloakResource,
+        obj: Any,
     ) -> bool:
         """Checks object permissions.
 

--- a/pinakes/main/catalog/permissions.py
+++ b/pinakes/main/catalog/permissions.py
@@ -13,12 +13,7 @@ from pinakes.common.auth.keycloak_django.permissions import (
     check_resource_permission,
     get_permitted_resources,
 )
-from pinakes.main.catalog.models import (
-    Portfolio,
-)
-
-# FIXME(cutwater): Permission classes share a lot of common code and must be
-#   refactored
+from pinakes.main.catalog.models import Portfolio
 
 
 class PortfolioPermission(BaseKeycloakPermission):
@@ -58,8 +53,10 @@ class PortfolioPermission(BaseKeycloakPermission):
         )
 
     def perform_check_object_permission(
-        self, permission, request: Request, view: Any, obj: Portfolio
+        self, permission, request: Request, view: Any, obj: Any
     ) -> bool:
+        if not isinstance(obj, Portfolio):
+            return False
         return check_resource_permission(
             obj.keycloak_type(),
             obj.keycloak_name(),


### PR DESCRIPTION
The method `BaseKeycloakPermission.perform_check_object_permission`
may be called not only with instances of AbstractKeycloakResource.