### PR TITLE
Fix HTTP 400 from Keycloak when querying non-existing resource

### DIFF
--- a/pinakes/common/auth/keycloak_django/permissions.py
+++ b/pinakes/common/auth/keycloak_django/permissions.py
@@ -26,6 +26,7 @@ from pinakes.common.auth.keycloak import (
     models as keycloak_models,
 )
 from pinakes.common.auth.keycloak.authz import AuthzClient
+from pinakes.common.auth.keycloak_django import AbstractKeycloakResource
 from pinakes.common.auth.keycloak_django.utils import (
     make_scope_name,
     make_resource_name,
@@ -216,6 +217,21 @@ def check_resource_permission(
         scope=scope,
     )
     return client.check_permissions([wildcard_permission, object_permission])
+
+
+def check_object_permission(
+    obj: AbstractKeycloakResource,
+    permission: str,
+    client: AuthzClient,
+):
+    if obj.keycloak_id:
+        return check_resource_permission(
+            obj.keycloak_type(), obj.keycloak_name(), permission, client
+        )
+    else:
+        return check_wildcard_permission(
+            obj.keycloak_type(), permission, client
+        )
 
 
 @dataclass(frozen=True)

--- a/pinakes/common/auth/keycloak_django/tests/test_permission_checks.py
+++ b/pinakes/common/auth/keycloak_django/tests/test_permission_checks.py
@@ -4,10 +4,10 @@ from pinakes.common.auth.keycloak.models import (
     AuthzPermission,
     AuthzResource,
 )
-
-from ..permissions import (
+from pinakes.common.auth.keycloak_django.permissions import (
     check_wildcard_permission,
     check_resource_permission,
+    check_object_permission,
     get_permitted_resources,
 )
 
@@ -41,6 +41,61 @@ def test_check_resource_permission():
             AuthzPermission("myresource:1", "myresource:read"),
         ]
     )
+
+
+@mock.patch(
+    "pinakes.common.auth.keycloak_django."
+    "permissions.check_wildcard_permission",
+    return_value=False,
+)
+@mock.patch(
+    "pinakes.common.auth.keycloak_django"
+    ".permissions.check_resource_permission",
+    return_value=True,
+)
+def test_check_object_permission_exists(
+    check_resource_permission, check_wildcard_permission
+):
+    obj = mock.Mock()
+    obj.keycloak_id = "598802c2-6266-40f0-9558-142e2cb0d98e"
+    obj.keycloak_type.return_value = "myresource"
+    obj.keycloak_name.return_value = "myresource:1"
+
+    client = mock.Mock()
+
+    assert check_object_permission(obj, "read", client) is True
+
+    check_resource_permission.assert_called_once_with(
+        "myresource", "myresource:1", "read", client
+    )
+    check_wildcard_permission.assert_not_called()
+
+
+@mock.patch(
+    "pinakes.common.auth.keycloak_django"
+    ".permissions.check_wildcard_permission",
+    return_value=True,
+)
+@mock.patch(
+    "pinakes.common.auth.keycloak_django"
+    ".permissions.check_resource_permission",
+    return_value=False,
+)
+def test_check_object_permission_not_exists(
+    check_resource_permission, check_wildcard_permission
+):
+    obj = mock.Mock()
+    obj.keycloak_id = None
+    obj.keycloak_type.return_value = "myresource"
+
+    client = mock.Mock()
+
+    assert check_object_permission(obj, "read", client) is True
+
+    check_wildcard_permission.assert_called_once_with(
+        "myresource", "read", client
+    )
+    check_resource_permission.assert_not_called()
 
 
 def test_get_permitted_resources_empty():

--- a/pinakes/main/catalog/permissions.py
+++ b/pinakes/main/catalog/permissions.py
@@ -11,15 +11,10 @@ from pinakes.common.auth.keycloak_django.permissions import (
     KeycloakPolicy,
     BaseKeycloakPermission,
     check_wildcard_permission,
-    check_resource_permission,
+    check_object_permission,
     get_permitted_resources,
 )
-from pinakes.main.catalog.models import (
-    Portfolio,
-    PortfolioItem,
-    Order,
-    OrderItem,
-)
+from pinakes.main.catalog.models import Portfolio, PortfolioItem, Order
 
 
 class PortfolioPermission(BaseKeycloakPermission):
@@ -62,9 +57,8 @@ class PortfolioPermission(BaseKeycloakPermission):
     ) -> bool:
         if not isinstance(obj, Portfolio):
             return False
-        return check_resource_permission(
-            obj.keycloak_type(),
-            obj.keycloak_name(),
+        return check_object_permission(
+            obj,
             permission,
             get_authz_client(request.keycloak_user.access_token),
         )
@@ -125,9 +119,8 @@ class PortfolioItemPermission(BaseKeycloakPermission):
             obj = obj.portfolio
         elif not isinstance(obj, Portfolio):
             return False
-        return check_resource_permission(
-            obj.keycloak_type(),
-            obj.keycloak_name(),
+        return check_object_permission(
+            obj,
             permission,
             get_authz_client(request.keycloak_user.access_token),
         )

--- a/pinakes/main/catalog/tests/unit/test_portfolio_permissions.py
+++ b/pinakes/main/catalog/tests/unit/test_portfolio_permissions.py
@@ -81,10 +81,10 @@ def test_has_permission(check_wildcard_permission):
 
 @pytest.mark.django_db
 @mock.patch(
-    "pinakes.main.catalog.permissions.check_resource_permission",
+    "pinakes.main.catalog.permissions.check_object_permission",
     return_value=True,
 )
-def test_has_object_permission(check_resource_permission):
+def test_has_object_permission(check_object_permission):
     request = mock.Mock()
     view = mock.Mock(action="retrieve")
     portfolio = PortfolioFactory()
@@ -92,9 +92,8 @@ def test_has_object_permission(check_resource_permission):
     permission = PortfolioPermission()
     assert permission.has_object_permission(request, view, portfolio) is True
 
-    check_resource_permission.assert_called_once_with(
-        "catalog:portfolio",
-        f"catalog:portfolio:{portfolio.id}",
+    check_object_permission.assert_called_once_with(
+        portfolio,
         "read",
         mock.ANY,
     )


### PR DESCRIPTION
In some cases Keycloak sends HTTP 400 BadRequest, when some of resources
included in the permission evaluation query don't exist.

https://issues.redhat.com/browse/SSP-2788