### PR TITLE
Minikube: Fix redirect when accessing Keycloak via HTTP

### DIFF
--- a/tools/minikube/templates/ingress.yaml
+++ b/tools/minikube/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/preserve-trailing-slash: "true"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
When trying to open in browser `http://keycloak.k8s.loca/auth/`,
Ingress issues 308 redirect to `https://keycloak.k8s.local/auth`
(without trailing slash) and then Keycloak issues another redirect
with trailing slash but to http, which creates a redirect loop.