### PR TITLE
Refactor SanitizeParameters to add more validations based on schema

### DIFF
--- a/pinakes/main/catalog/services/compute_runtime_parameters.py
+++ b/pinakes/main/catalog/services/compute_runtime_parameters.py
@@ -10,6 +10,7 @@ class ComputeRuntimeParameters:
     def __init__(self, order_item):
         self.order_item = order_item
         self.runtime_parameters = {}
+        self.substituted = False
 
     def process(self):
         if self.order_item.inventory_service_plan_ref is None:
@@ -55,4 +56,5 @@ class ComputeRuntimeParameters:
 
     # TODO:
     def _substitution(self, value):
+        self.substituted = True
         return value

--- a/pinakes/main/catalog/services/provision_order_item.py
+++ b/pinakes/main/catalog/services/provision_order_item.py
@@ -15,7 +15,10 @@ class ProvisionOrderItem:
         """Process a single order item"""
         portfolio_item = self.order_item.portfolio_item
         params = {}
-        params["service_parameters"] = self.order_item.service_parameters
+        params["service_parameters"] = (
+            self.order_item.service_parameters_raw
+            or self.order_item.service_parameters
+        )
         params["service_plan_id"] = None
 
         svc = StartTowerJob(

--- a/pinakes/main/catalog/tests/functional/test_order_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_order_end_points.py
@@ -234,12 +234,8 @@ def test_order_order_item_post(api_request, mocker):
     portfolio_item = PortfolioItemFactory(
         service_offering_ref=service_offering.id
     )
-    service_plan = ServicePlanFactory(
-        portfolio_item=portfolio_item,
-    )
-    data = {
-        "portfolio_item": portfolio_item.id,
-    }
+    service_plan = ServicePlanFactory(portfolio_item=portfolio_item)
+    data = {"portfolio_item": portfolio_item.id, "service_parameters": {}}
     response = api_request(
         "post", "catalog:order-orderitem-list", order.id, data
     )
@@ -247,5 +243,4 @@ def test_order_order_item_post(api_request, mocker):
     assert response.status_code == 201
     assert content["name"] == portfolio_item.name
     assert content["order"] == str(order.id)
-    assert content["inventory_service_plan_ref"] == str(service_plan.id)
     perform_check_permission.assert_called_once()

--- a/pinakes/main/catalog/tests/services/test_compute_runtime_parameters.py
+++ b/pinakes/main/catalog/tests/services/test_compute_runtime_parameters.py
@@ -194,3 +194,4 @@ def test_process_with_service_parameters_in_schema():
         "dev_null": "change in future",
         "flexible": "in schema fields",
     }
+    assert svc.substituted is True

--- a/pinakes/main/catalog/tests/services/test_sanitize_parameters.py
+++ b/pinakes/main/catalog/tests/services/test_sanitize_parameters.py
@@ -4,69 +4,112 @@ import pytest
 from pinakes.main.catalog.services.sanitize_parameters import (
     SanitizeParameters,
 )
-from pinakes.main.catalog.tests.factories import (
-    OrderItemFactory,
-    PortfolioItemFactory,
-    ServicePlanFactory,
-)
+from pinakes.main.catalog.tests.factories import ServicePlanFactory
+from pinakes.main.catalog.exceptions import BadParamsException
+
+
+_FIELDS = [
+    {
+        "name": "Totally not a pass",
+        "type": "password",
+        "label": "Totally not a pass",
+        "component": "text-field",
+        "helperText": "",
+        "isRequired": True,
+        "initialValue": "",
+    },
+    {
+        "name": "most_important_var1",
+        "label": "secret field 1",
+        "component": "textarea-field",
+        "helperText": "Has no effect on anything, ever.",
+        "initialValue": "",
+    },
+    {
+        "name": "token idea",
+        "label": "field 1",
+        "component": "textarea-field",
+        "helperText": "Don't look.",
+        "initialValue": "",
+    },
+    {
+        "name": "name",
+        "label": "field 1",
+        "component": "textarea-field",
+        "helperText": "That's not my name.",
+        "initialValue": "{{product.artifacts.testk}}",
+        "isSubstitution": True,
+    },
+    {
+        "name": "optional",
+        "label": "field 1",
+        "component": "textarea-field",
+        "helperText": "An optional field",
+    },
+]
+
+_BASE = {"schema": {"fields": _FIELDS}}
 
 
 @pytest.mark.django_db
-def test_sanitize_parameters_from_service_plan_base():
-    fields = [
-        {
-            "name": "Totally not a pass",
-            "type": "password",
-            "label": "Totally not a pass",
-            "component": "text-field",
-            "helperText": "",
-            "isRequired": True,
-            "initialValue": "",
-        },
-        {
-            "name": "most_important_var1",
-            "label": "secret field 1",
-            "component": "textarea-field",
-            "helperText": "Has no effect on anything, ever.",
-            "initialValue": "",
-        },
-        {
-            "name": "token idea",
-            "label": "field 1",
-            "component": "textarea-field",
-            "helperText": "Don't look.",
-            "initialValue": "",
-        },
-        {
-            "name": "name",
-            "label": "field 1",
-            "component": "textarea-field",
-            "helperText": "That's not my name.",
-            "initialValue": "{{product.artifacts.testk}}",
-            "isSubstitution": True,
-        },
-    ]
-
-    base = {"schema": {"fields": fields}}
+def test_sanitize_parameters_for_secrets():
     service_parameters = {
         "name": "Joe",
         "Totally not a pass": "s3crete",
         "token idea": "my secret",
     }
 
-    portfolio_item = PortfolioItemFactory()
-    service_plan = ServicePlanFactory(
-        portfolio_item=portfolio_item, base_schema=base
-    )
-    order_item = OrderItemFactory(
-        portfolio_item=portfolio_item,
-        service_parameters=service_parameters,
-        inventory_service_plan_ref=str(service_plan.id),
-    )
+    service_plan = ServicePlanFactory(base_schema=_BASE)
 
-    svc = SanitizeParameters(order_item).process()
+    svc = SanitizeParameters(service_plan, service_parameters).process()
     assert svc.sanitized_parameters == {
         "name": "Joe",
         "Totally not a pass": "$protected$",
         "token idea": "$protected$",
     }
+
+
+@pytest.mark.django_db
+def test_sanitize_parameters_optional_but_empty():
+    service_parameters = {
+        "name": "Joe",
+        "Totally not a pass": "s3crete",
+        "token idea": "my secret",
+        "optional": None,
+    }
+
+    service_plan = ServicePlanFactory(base_schema=_BASE)
+
+    svc = SanitizeParameters(service_plan, service_parameters).process()
+    assert svc.sanitized_parameters == {
+        "name": "Joe",
+        "Totally not a pass": "$protected$",
+        "token idea": "$protected$",
+    }
+
+
+@pytest.mark.django_db
+def test_sanitize_parameters_required_but_empty():
+    service_parameters = {
+        "name": "Joe",
+        "Totally not a pass": None,
+        "token idea": "my secret",
+    }
+
+    service_plan = ServicePlanFactory(base_schema=_BASE)
+
+    with pytest.raises(BadParamsException):
+        SanitizeParameters(service_plan, service_parameters).process()
+
+
+@pytest.mark.django_db
+def test_sanitize_parameters_required_but_missing():
+    service_parameters = {
+        "name": "Joe",
+        "token idea": "my secret",
+    }
+
+    service_plan = ServicePlanFactory(base_schema=_BASE)
+
+    with pytest.raises(BadParamsException):
+        SanitizeParameters(service_plan, service_parameters).process()

--- a/pinakes/main/catalog/tests/services/test_start_order_item.py
+++ b/pinakes/main/catalog/tests/services/test_start_order_item.py
@@ -1,6 +1,7 @@
 """ Start ordering an item """
 
 import pytest
+from unittest import mock
 
 from pinakes.main.catalog.models import (
     Order,
@@ -13,9 +14,16 @@ from pinakes.main.catalog.services.start_order_item import (
 from pinakes.main.catalog.services.provision_order_item import (
     ProvisionOrderItem,
 )
+from pinakes.main.catalog.services.sanitize_parameters import (
+    SanitizeParameters,
+)
+from pinakes.main.catalog.services.compute_runtime_parameters import (
+    ComputeRuntimeParameters,
+)
 from pinakes.main.catalog.tests.factories import (
     OrderFactory,
     OrderItemFactory,
+    ServicePlanFactory,
 )
 
 
@@ -36,7 +44,7 @@ def test_place_order_item(mocker):
 
 
 @pytest.mark.django_db
-def test_place_order_item_raise_error(mocker):
+def test_place_order_item_raise_provisioning_error(mocker):
     order = OrderFactory()
     order_item = OrderItemFactory(state=OrderItem.State.PENDING, order=order)
 
@@ -49,3 +57,84 @@ def test_place_order_item_raise_error(mocker):
     order_item.refresh_from_db()
 
     assert order_item.state == Order.State.FAILED
+
+
+@pytest.mark.django_db
+def test_place_order_item_raise_validation_error(mocker):
+    order = OrderFactory()
+    order_item = OrderItemFactory(state=OrderItem.State.PENDING, order=order)
+
+    mocker.patch(
+        "pinakes.main.catalog.services.validate_order_item",
+        side_effect=Exception("mocker error"),
+    )
+    svc = StartOrderItem(order)
+    svc.process()
+    order_item.refresh_from_db()
+
+    assert order_item.state == Order.State.FAILED
+
+
+@pytest.mark.django_db
+def test_place_order_item_runtime_substitution(mocker):
+    service_params = {"key": "val"}
+    substituted_params = {"key": "sub"}
+    order = OrderFactory()
+    order_item = OrderItemFactory(
+        state=OrderItem.State.PENDING,
+        order=order,
+        service_parameters=service_params,
+        inventory_service_plan_ref="1",
+    )
+    ServicePlanFactory(inventory_service_plan_ref="1", base_schema={})
+
+    mocker.patch.object(
+        ComputeRuntimeParameters,
+        "process",
+        return_value=mock.Mock(
+            substituted=True, runtime_parameters=substituted_params
+        ),
+    )
+    mocker.patch.object(
+        SanitizeParameters,
+        "process",
+        return_value=mock.Mock(sanitized_parameters=substituted_params),
+    )
+    mocker.patch.object(ProvisionOrderItem, "process", return_value=None)
+    StartOrderItem(order).process()
+    order_item.refresh_from_db()
+
+    assert order_item.service_parameters == substituted_params
+
+
+@pytest.mark.django_db
+def test_place_order_item_runtime_substitution_secret(mocker):
+    service_params = {"key": "val"}
+    substituted_params = {"key": "sub"}
+    hidden_params = {"key": "$secret"}
+    order = OrderFactory()
+    order_item = OrderItemFactory(
+        state=OrderItem.State.PENDING,
+        order=order,
+        service_parameters=service_params,
+        inventory_service_plan_ref="1",
+    )
+    ServicePlanFactory(inventory_service_plan_ref="1", base_schema={})
+
+    mocker.patch.object(
+        ComputeRuntimeParameters,
+        "process",
+        return_value=mock.Mock(
+            substituted=True, runtime_parameters=substituted_params
+        ),
+    )
+    mocker.patch.object(
+        SanitizeParameters,
+        "process",
+        return_value=mock.Mock(sanitized_parameters=hidden_params),
+    )
+    mocker.patch.object(ProvisionOrderItem, "process", return_value=None)
+    StartOrderItem(order).process()
+    order_item.refresh_from_db()
+    assert order_item.service_parameters == hidden_params
+    assert order_item.service_parameters_raw == substituted_params

--- a/pinakes/main/catalog/tests/unit/test_order_items.py
+++ b/pinakes/main/catalog/tests/unit/test_order_items.py
@@ -141,7 +141,9 @@ def test_sanitized_params():
     order = OrderFactory(tenant=tenant, user=user)
     portfolio_item = PortfolioItemFactory()
     service_plan = ServicePlanFactory(
-        portfolio_item=portfolio_item, base_schema=base
+        portfolio_item=portfolio_item,
+        base_schema=base,
+        inventory_service_plan_ref="1",
     )
 
     service_parameters = {
@@ -165,4 +167,5 @@ def test_sanitized_params():
         "Totally not a pass": "$protected$",
         "token idea": "$protected$",
     }
+    order_item.refresh_from_db()
     assert order_item.service_parameters_raw == service_parameters


### PR DESCRIPTION
Fix a few bugs when setting or using service parameters

https://issues.redhat.com/browse/SSP-2777
https://issues.redhat.com/browse/SSP-2778
https://issues.redhat.com/browse/SSP-2760

Remove a parameter if it has no value and is not required
Raise an error if a parameter is required but it is missing or has no value.

Fix bugs
Properly save service_parameters and service_parameters_raw when creating an order item.
Properly save service_parameters and service_parameters_raw  after the substitution.
Use service_parameters or service_parameters_raw at provisioning.