### PR TITLE
force disable ssl for postgres in docker-compose environments

### DIFF
--- a/tools/docker/docker-compose.override.yml
+++ b/tools/docker/docker-compose.override.yml
@@ -22,6 +22,7 @@ x-environment:
   - PINAKES_POSTGRES_HOST=postgres
   - PINAKES_POSTGRES_USER=admin
   - PINAKES_POSTGRES_PASSWORD=admin
+  - PINAKES_POSTGRES_SSL_MODE=disable
 
 services:
   frontend:

--- a/tools/docker/docker-compose.stage.yml
+++ b/tools/docker/docker-compose.stage.yml
@@ -22,6 +22,7 @@ x-environment:
   - PINAKES_POSTGRES_HOST=postgres
   - PINAKES_POSTGRES_USER=admin
   - PINAKES_POSTGRES_PASSWORD=admin
+  - PINAKES_POSTGRES_SSL_MODE=disable
 
 services:
   frontend:


### PR DESCRIPTION
Disable ssl for postgres for docker-compose environments. 

Depends on #423 