### PR TITLE
Add .gitleaks.toml to remove false positives from scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+title = "Pinakes Gitleaks Config"
+
+[allowlist]
+  description = "Allowlist"
+  regexes = ['''SOMESECRETVALUE''', '''settings\.KEYCLOAK_CLIENT_SECRET''']
+  paths = ['''tools.*\.key''']


### PR DESCRIPTION
Now that we are public we need to include this file to remove the false positives we know should not trigger the security flag.

If you have gitleaks installed you should be able to run this command from our root directory to see no issues:
```
gitleaks -v --additional-config .gitleaks.toml --path ./
```