### PR TITLE
Expose group_name in request apis

### DIFF
--- a/pinakes/main/approval/serializers.py
+++ b/pinakes/main/approval/serializers.py
@@ -121,6 +121,7 @@ class RequestFields:
     FIELDS = (
         "id",
         "requester_name",
+        "group_name",
         "owner",
         "name",
         "description",

--- a/pinakes/main/approval/tests/functional/test_request_end_points.py
+++ b/pinakes/main/approval/tests/functional/test_request_end_points.py
@@ -35,12 +35,12 @@ def test_request_list(api_request, mocker):
 @pytest.mark.django_db
 def test_request_retrieve(api_request, mocker):
     obj_permission = mocker.spy(RequestPermission, "has_object_permission")
-    request = RequestFactory()
+    request = RequestFactory(group_name="group1")
     response = api_request("get", "approval:request-detail", request.id)
 
     assert response.status_code == 200
-    content = json.loads(response.content)
-    assert content["id"] == request.id
+    assert response.data["id"] == request.id
+    assert response.data["group_name"] == request.group_name
     obj_permission.assert_called_once()
 
 


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/SSP-2825.
Groups assigned to a request can be useful to distinguish requests.