### PR TITLE
Clear expired sessions

### DIFF
--- a/pinakes/main/common/tasks.py
+++ b/pinakes/main/common/tasks.py
@@ -6,7 +6,7 @@ import rq
 from django.db import transaction
 from django.conf import settings
 from django.utils import timezone as django_tz
-from django.contrib.sessions.management.commands.clearsessions import Command
+from django.contrib.sessions.management.commands import clearsessions
 
 from pinakes.common.auth import keycloak_django
 from pinakes.common.auth.keycloak import (
@@ -103,7 +103,7 @@ def sync_external_groups():
 
 
 def clear_sessions():
-    Command().handle()
+    clearsessions.Command().handle()
 
 
 def _manage_roles(obj, group_roles):

--- a/pinakes/main/common/tasks.py
+++ b/pinakes/main/common/tasks.py
@@ -6,6 +6,7 @@ import rq
 from django.db import transaction
 from django.conf import settings
 from django.utils import timezone as django_tz
+from django.contrib.sessions.management.commands.clearsessions import Command
 
 from pinakes.common.auth import keycloak_django
 from pinakes.common.auth.keycloak import (
@@ -99,6 +100,10 @@ def sync_external_groups():
         updated_count,
         deleted_count,
     )
+
+
+def clear_sessions():
+    Command().handle()
 
 
 def _manage_roles(obj, group_roles):

--- a/pinakes/settings/defaults.py
+++ b/pinakes/settings/defaults.py
@@ -334,6 +334,10 @@ RQ_CRONJOBS = [
         CRONTAB,
         "pinakes.main.inventory.tasks.refresh_all_sources",
     ),
+    (
+        "* 0 * * *",
+        "pinakes.main.common.tasks.clear_sessions",
+    ),
 ]
 
 # Auto generation of openapi spec using Spectacular


### PR DESCRIPTION
Since we use session based authentication there are times when
a user might not logout and leave a session dangling. These sessions
have to be cleared according to Django documentation.
This PR clears out stale sessions everyday at midnight