### PR TITLE
Fix start_pods script when env vars are missing

### DIFF
--- a/tools/minikube/scripts/start_pods.sh
+++ b/tools/minikube/scripts/start_pods.sh
@@ -5,20 +5,25 @@
 # export PINAKES_CONTROLLER_TOKEN=<<your controller token>>
 # export PINAKES_CONTROLLER_VERIFY_SSL=True|False
 
+set -o nounset
 set -o errexit
 
+PINAKES_CONTROLLER_URL=${PINAKES_CONTROLLER_URL:-}
+PINAKES_CONTROLLER_TOKEN=${PINAKES_CONTROLLER_TOKEN:-}
+PINAKES_CONTROLLER_VERIFY_SSL=${PINAKES_CONTROLLER_VERIFY_SSL:-}
+
 if [[ -z "${PINAKES_CONTROLLER_URL}" ]]; then
-  echo "Warning: Please set the environment variable PINAKES_CONTROLLER_URL"
+  echo "Error: Environment variable PINAKES_CONTROLLER_URL is not set."
   exit 1
 fi
 
 if [[ -z "${PINAKES_CONTROLLER_TOKEN}" ]]; then
-  echo "Warning: Please set the environment variable PINAKES_CONTROLLER_TOKEN"
+  echo "Error: Environment variable PINAKES_CONTROLLER_TOKEN is not set."
   exit 1
 fi
 
 if [[ -z "${PINAKES_CONTROLLER_VERIFY_SSL}" ]]; then
-  echo "Warning: Please set the environment variable PINAKES_CONTROLLER_VERIFY_SSL"
+  echo "Error: Environment variable PINAKES_CONTROLLER_VERIFY_SSL is not set."
   exit 1
 fi
 

--- a/tools/minikube/scripts/start_pods.sh
+++ b/tools/minikube/scripts/start_pods.sh
@@ -5,23 +5,21 @@
 # export PINAKES_CONTROLLER_TOKEN=<<your controller token>>
 # export PINAKES_CONTROLLER_VERIFY_SSL=True|False
 
-set -o nounset
 set -o errexit
 
-PINAKES_CONTROLLER_URL=${PINAKES_CONTROLLER_URL:-}
-PINAKES_CONTROLLER_TOKEN=${PINAKES_CONTROLLER_TOKEN:-}
-PINAKES_CONTROLLER_VERIFY_SSL=${PINAKES_CONTROLLER_VERIFY_SSL:-}
-
 if [[ -z "${PINAKES_CONTROLLER_URL}" ]]; then
-  echo "Warning: PINAKES_CONTROLLER_URL is not set."
+  echo "Warning: Please set the environment variable PINAKES_CONTROLLER_URL"
+  exit 1
 fi
 
 if [[ -z "${PINAKES_CONTROLLER_TOKEN}" ]]; then
-  echo "Warning: PINAKES_CONTROLLER_TOKEN is not set."
+  echo "Warning: Please set the environment variable PINAKES_CONTROLLER_TOKEN"
+  exit 1
 fi
 
 if [[ -z "${PINAKES_CONTROLLER_VERIFY_SSL}" ]]; then
-  echo "Warning: PINAKES_CONTROLLER_VERIFY_SSL is not set."
+  echo "Warning: Please set the environment variable PINAKES_CONTROLLER_VERIFY_SSL"
+  exit 1
 fi
 
 if ! kubectl get namespace catalog &>/dev/null; then


### PR DESCRIPTION
If the env_vars is missing the script doesn't exist, it creates
an incomplete env which needs to be cleaned up.

If we leave the set -o nounset and the env var is missing the error
generated is not user friendly

./tools/minikube/scripts/start_pods.sh: line 11: PINAKES_CONTROLLER_URL: unbound variable