### PR TITLE
[SSP-2842]Add service class for sending email

### DIFF
--- a/pinakes/data/email_template.html
+++ b/pinakes/data/email_template.html
@@ -1,0 +1,582 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Red Hat Insights</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;700&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Text&display=swap');
+
+    .rh-masthead__content-title,
+    .rh-masthead__metric-block-count,
+    .rh-masthead__metric-block-text,
+    .rh-masthead__subhead {
+      font-family: 'Red Hat Display', Helvetica, sans-serif;
+    }
+
+    body,
+    .rh-content__block,
+    .rh-data-table,
+    .rh-masthead__subhead {
+      font-family: 'Red Hat Text', Helvetica, sans-serif;
+    }
+
+    #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" message */
+    body, table, td, p, a, li, blockquote{-webkit-text-size-adjust:100%; -ms-text-size-adjust:100%;} /* Prevent WebKit and Windows mobile changing default text sizes */
+    table, td{mso-table-lspace:0pt; mso-table-rspace:0pt;} /* Remove spacing between tables in Outlook 2007 and up */
+    img{-ms-interpolation-mode:bicubic;} /* Allow smoother rendering of resized image in Internet Explorer */
+
+    /* reset styles */
+    img{border:0; height:auto; line-height:100%; outline:none; text-decoration:none;}
+    table{border-collapse:collapse !important;}
+
+    /* Remove space around email design */
+    html,
+    body {
+      margin: 0 auto !important;
+      padding: 0 !important;
+      height: 100% !important;
+      width: 100% !important;
+      background-color: #fff;
+    }
+
+    /* Stop Outlook resizing small text */
+    * {
+      -ms-text-size-adjust: 100%;
+    }
+    /* Stop Outlook from adding extra spacing to tables */
+    table, td {
+      mso-table-lspace: 0pt !important;
+      mso-table-rspace: 0pt !important;
+    }
+    /* Better rendering method when resizing impages in Outlook IE */
+    img {
+      -ms-interpolation-mode:bicubic;
+    }
+
+    a {
+      text-decoration: none;
+      color: #fff;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      font-family: 'Red Hat Display', sans-serif;
+      font-size: 18px;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p {
+      margin-top: 0;
+    }
+
+    h1:last-child,
+    h2:last-child,
+    h3:last-child,
+    h4:last-child,
+    h5:last-child,
+    h6:last-child,
+    p:last-child {
+      margin-bottom: 0;
+    }
+
+
+    .rh-masthead__content-title h1,
+    .rh-masthead__content-title h2,
+    .rh-masthead__content-title h3,
+    .rh-masthead__content-title h4,
+    .rh-masthead__subhead h1,
+    .rh-masthead__subhead h2,
+    .rh-masthead__subhead h3,
+    .rh-masthead__subhead h4 {
+      font-weight: 400;
+      line-height: 1;
+    }
+
+    .rh-body-table,
+    .rh-body-cell {
+      height:100% !important;
+      margin:0;
+      padding:0;
+      width:100% !important;
+    }
+
+    .rh-body-table {
+      background-color: #f5f5f5;
+      background-color: #fff;
+    }
+
+    .rh-page {
+      padding: 0 0 30px 0;
+      background: #efefef;
+    }
+
+    .rh-template-container {
+      padding: 0 0 30px 0;
+      width: 600px;
+    }
+
+    .rh-template-container,
+    .rh-template-container > tbody {
+      background: #ededed;
+    }
+
+    .rh-head,
+    .rh-body,
+    .rh-footer {
+      margin: 0;
+      mso-line-height-rule: exactly;
+      font-family: arial;
+      font-size: 16px;
+      box-sizing: border-box;
+    }
+
+    .rh-body {
+      padding: 0 20px 20px 20px;
+    }
+
+    .rh-body,
+    .rh-masthead,
+    .rh-content,
+    .rh-data-table,
+    .rh-head {
+      width: 100% !important;
+    }
+
+    .rh-head {
+      padding: 0 0 20px 0;
+    }
+
+    .rh-footer {
+      padding: 10px 20px 30px 20px;
+    }
+
+    .rh-masthead__content {
+      background-color: #090a0a !important;
+      background-color: #030303 !important;
+      background-image: url(https://raw.githubusercontent.com/RedHatInsights/frontend-assets/master/src/email-assets/bg_masthead-hat.png);
+      background-size: cover;
+    }
+
+    .rh-masthead__subhead {
+      background-color: #282828 !important;
+      padding: 20px;
+      color: #ffffff !important;
+      font-size: 18px;
+      text-align: center;
+    }
+
+    .rh-masthead__block {
+      width: 200px;
+    }
+
+    .rh-masthead__brand {
+      padding: 20px 20px 20px 20px;
+      background-color: #151515 !important;
+      background-repeat: repeat;
+      background-image: url(https://raw.githubusercontent.com/RedHatInsights/frontend-assets/master/src/email-assets/bg_151515.jpg);
+      text-align: center;
+    }
+
+    .rh-masthead__brand-link {
+      display: block;
+      text-align: center;
+    }
+
+    .rh-masthead__content {
+      background-color: #151515;
+      background-size: cover;
+      background-repeat: no-repeat;
+    }
+
+    .rh-masthead__content-title {
+      padding: 20px 20px 20px 20px;
+      margin: 0 0 10px 0;
+      color: #ffffff;
+      font-size: 18px;
+      position: relative;
+      font-weight: 400;
+    }
+
+    .rh-masthead__metric-block-count {
+      display: block;
+      padding-bottom: 10px;
+      text-align: center;
+      font-size: 28px;
+      word-break:break-all;
+      color: #ffffff !important;
+      line-height: 1;
+    }
+
+    .rh-masthead__metric-block-text {
+      display: block;
+      padding: 0 20px 40px 20px;
+      word-break: break-all;
+      color: #ffffff !important;
+      line-height: 1;
+      font-size: 14px;
+    }
+
+    .rh-masthead__metric-block-icon {
+      padding: 0 0 20px;
+      display: block;
+    }
+
+    .rh-content + .rh-content {
+      padding: 0 0 20px 0;
+    }
+
+    .rh-content a {
+      color: #0066cc;
+    }
+
+    .rh-content {
+      background: #efefef;
+    }
+
+    .rh-content table {
+      background: #fff;
+    }
+
+    /* Content block */
+    .rh-content__block {
+      max-width: 100%;
+      padding: 20px 20px 20px 20px;
+      overflow: hidden;
+    }
+
+    .rh-content tr + tr .rh-content__block {
+      padding-top: 0;
+    }
+
+    .rh-content .rh-content__block {
+      background-color: #fff;
+    }
+
+    .rh-content__block-title {
+      font-weight: bold;
+    }
+
+    .rh-footer__text {
+      font-size: 14px;
+    }
+
+    .rh-footer__text a {
+      color: #0066cc;
+    }
+
+    .rh-content__spacer {
+      font-size: 0;
+      line-height: 0;
+      height: 20px;
+      background-color: #ffffff;
+    }
+
+    .rh-cta-link {
+      display:block;
+      padding: 10px 20px;
+      background-color: #0066cc;
+      border-radius: 3px;
+      text-decoration:none;
+      font-weight:bold;
+    }
+
+    .rh-cta-link a {
+      color:#ffffff;
+      text-decoration: none;
+    }
+
+    .rh-data-table thead th {
+      font-weight: 700;
+      text-align: left;
+    }
+
+    .rh-data-table tbody th, .rh-data-table tbody td {
+      padding-top: 20px;
+      vertical-align: top;
+    }
+
+    .rh-data-table tbody th {
+      font-weight: 900;
+      text-align: left;
+      width: 200px;
+    }
+
+    .rh-data-table.rh-m-bordered th {
+      padding: 10px;
+      text-align: left;
+      font-size: 14px;
+      font-weight: 500;
+      text-transform: uppercase;
+      background-color: #ededed;
+    }
+
+    .rh-data-table.rh-m-bordered td {
+      padding: 10px;
+      text-align: left;
+    }
+
+    .rh-data-table.rh-m-bordered {
+      border-collapse: collapse;
+    }
+
+    .rh-table-header {
+      text-align: left;
+      padding-bottom: 0;
+    }
+
+    .rh-m-bordered th,
+    .rh-m-bordered td {
+      border-width: 1px;
+      border-color: #b8bbbe;
+      border-style: solid;
+    }
+
+    .rh-m-bordered tr:nth-child(even) {
+      background-color: #fafafa;
+    }
+
+    .rh-color__red {
+      color: #a30000;
+    }
+
+    .rh-color__orange {
+      color: #ec7a08;
+    }
+
+    .rh-color__green {
+      color: #486b00;
+    }
+
+    .rh-m-block {
+      display: block;
+    }
+
+    .rh-url {
+      word-break: break-word;
+    }
+
+    .rh-stack > * + * {
+      margin-top: 10px;
+    }
+
+    .rh-inline {
+      display: flex;
+      align-items: center;
+    }
+
+    .rh-icon {
+      display: inline-block;
+    }
+
+    .rh-inline > * + * {
+      display: inline-block;
+      margin-left: 5px;
+    }
+
+    /* dark mode hacks */
+    [data-ogsc] .rh-masthead__brand,
+    [data-ogsb] .rh-masthead__brand {
+      background-color: #151515 !important;
+    }
+
+    @media only screen and (max-width: 320px) {
+      .rh-masthead__block {
+        width: 100% !important;
+        display: block !important;
+      }
+    }
+
+    @media only screen and (max-width: 480px) {
+      .rh-template-container {
+        max-width: 480px !important;
+        /*@editable*/ width:100% !important;
+      }
+
+      .rh-data-table tbody th {
+        width: auto !important;
+      }
+
+      .rh-data-table th,
+      .rh-data-table td {
+        font-size: 14px;
+      }
+
+      .rh-data-table.rh-m-bordered th,
+      .rh-data-table.rh-m-bordered td {
+        padding: 5px;
+        text-align: left;
+      }
+    }
+
+    @media only screen and (max-width: 600px) {
+      body{
+        width: 100% !important;
+        min-width: 100% !important;
+      }
+
+      .rh-template-container {
+        max-width: 600px !important;
+        /*@editable*/ width:100% !important;
+      }
+
+      .rh-masthead__block {
+        width: 33%;
+        max-width: 200px;
+      }
+    }
+  </style>
+
+  </head>
+
+  <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" class="rh-body">
+    <center>
+      <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" class="rh-body-table">
+        <tr>
+          <td align="center" valign="top" class="rh-body-cell">
+            <table border="0" cellpadding="0" cellspacing="0" class="rh-template-container">
+
+              <!-- Head -->
+              <tr>
+                <td class="rh-head">
+                  <table class="rh-masthead" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+                    <tr>
+                      <!--Red Hat logo-->
+                      <td align="center" class="rh-masthead__brand" bgcolor="#151515">
+                        <a href="https://github.com/ansible/pinakes" target="_blank" class="rh-masthead__brand-link">
+                          <img src="https://$web_url/ui/catalog/fonts/logo_small.svg" alt="Pinakes logo" width="270" height="82" class="rh-masthead__brand-img" />
+                        </a>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="rh-masthead__subhead">
+                        <h1>Approval Request ID $approval_id</h1>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <!-- end head -->
+
+              <!-- Body section -->
+              <tr>
+                <td class="rh-body">
+                  <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+
+                    <!-- Content block -->
+                    <tr>
+                      <td class="rh-content__block">
+                        <p>
+                          <strong>$approver_name,</strong>
+                          <br/>
+                          <br/>
+                          The following Pinakes order requires your approval:
+                        </p>
+                      </td>
+                    </tr>
+                    <!-- end content block -->
+
+                    <!-- Content block -->
+                    <tr>
+                      <td class="rh-content__block">
+                        <table class="rh-data-table">
+                          <tbody>
+                            <tr>
+                              <th role="rowheader" scope="row">Ordered by:</th>
+                              <td>
+                                $requester_name<br/> (<a href="mailto:$orderer_email">$orderer_email</a>)
+                                <br/>
+                              </td>
+                            </tr>
+                            <tr>
+                              <th role="rowheader" scope="row">Order ID:</th>
+                              <td>$order_id</td>
+                            </tr>
+                            <tr>
+                              <th role="rowheader" scope="row">Order date:</th>
+                              <td>$order_date</td>
+                            </tr>
+                            <tr>
+                              <th role="rowheader" scope="row">Order time:</th>
+                              <td>$order_time</td>
+                            </tr>
+                            <tr>
+                              <th role="rowheader" scope="row">Product:</th>
+                              <td>$product</td>
+                            </tr>
+                            <tr>
+                              <th role="rowheader" scope="row">Portfolio:</th>
+                              <td>$portfolio</td>
+                            </tr>
+                            <tr>
+                              <th role="rowheader" scope="row">Platform:</th>
+                              <td>$platform</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                    <!-- end content block -->
+
+                    <!-- Content block -->
+                    <tr>
+                      <td class="rh-content__block">
+                        <table align="center">
+                          <tr>
+                            <td class="rh-cta-link" align="center">
+                              <a target="_blank" href="$web_url/$approve_link">
+                                <span>
+                                  Process request
+                                </span>
+                              </a>
+                            </td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                    <!-- end content block -->
+
+                   <!-- end body section -->
+                  </table>
+                </td>
+              </tr>
+              <!-- end body section -->
+
+              <!-- Footer -->
+              <tr>
+                <td class="rh-footer">
+                  <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
+                    <tr>
+                      <td class="rh-footer__text">
+                        This email was sent by the Pinakes project
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <!-- end footer -->
+
+              <!-- Ensure padding bottom - don't remove empty row -->
+              <tr>
+                <td>
+                </td>
+              </tr>
+              <!-- leave - empty row -->
+
+            </table>
+          </td>
+        </tr>
+      </table>
+    </center>
+  </body>
+</html>

--- a/pinakes/main/approval/models.py
+++ b/pinakes/main/approval/models.py
@@ -11,6 +11,7 @@ from pinakes.common.auth.keycloak_django import AbstractKeycloakResource
 models.CharField.register_lookup(Length)
 
 
+# pylint: disable=no-member
 class NotificationType(ImageableModel, models.Model):
     """NotificationType model"""
 
@@ -191,6 +192,8 @@ class Workflow(KeycloakMixin, BaseModel):
 
 
 class RequestContext(models.Model):
+    """RequestContext model"""
+
     content = models.JSONField()
     context = models.JSONField()
 
@@ -202,6 +205,8 @@ class Request(AbstractKeycloakResource, BaseModel):
     KEYCLOAK_ACTIONS = ("read",)
 
     class State(models.TextChoices):
+        """State contants"""
+
         PENDING = "pending"
         SKIPPED = "skipped"
         STARTED = "started"
@@ -211,6 +216,8 @@ class Request(AbstractKeycloakResource, BaseModel):
         FAILED = "failed"
 
     class Decision(models.TextChoices):
+        """Decision constants"""
+
         UNDECIDED = "undecided"
         APPROVED = "approved"
         DENIED = "denied"
@@ -347,7 +354,7 @@ class Request(AbstractKeycloakResource, BaseModel):
 
     def is_root(self):
         """Is the request a root node"""
-        return False if self.parent else True
+        return not bool(self.parent)
 
     def is_leaf(self):
         """Is the request a leaf node"""
@@ -382,6 +389,8 @@ class Action(BaseModel):
     """Action model"""
 
     class Operation(models.TextChoices):
+        """Operation contants"""
+
         NOTIFY = "notify"
         START = "start"
         SKIP = "skip"

--- a/pinakes/main/approval/services/create_request.py
+++ b/pinakes/main/approval/services/create_request.py
@@ -17,8 +17,9 @@ logger = logging.getLogger("approval")
 class CreateRequest:
     """Create an approval request"""
 
-    def __init__(self, data):
+    def __init__(self, data, context={}):
         self.data = data
+        self.context = context
         self.request = None
         self.job = None
 
@@ -32,7 +33,7 @@ class CreateRequest:
 
         content = self.data.pop("content")
         request_context = RequestContext.objects.create(
-            content=content, context={}
+            content=content, context=self.context
         )
         self.request = Request.objects.create(
             request_context=request_context, **self.data

--- a/pinakes/main/approval/services/email_notification.py
+++ b/pinakes/main/approval/services/email_notification.py
@@ -1,0 +1,83 @@
+"""Email notification for an approval request"""
+import logging
+import string
+from importlib.resources import read_text
+from django.core.mail import send_mail
+from django.core.mail.backends.smtp import EmailBackend
+
+from pinakes.common.auth.keycloak_django.clients import get_admin_client
+
+logger = logging.getLogger("catalog")
+
+
+class EmailNotification:
+    """Service class for email notification"""
+
+    def __init__(self, request):
+        self.request = request
+
+    def process(self):
+        """process the service"""
+        self._send_mail()
+        return self
+
+    def _send_mail(self):
+        settings = self.request.workflow.template.process_method.settings
+        sender = settings.pop("from", None)
+        security = settings.pop("security", None)
+        if security:
+            settings[security] = True
+        backend = EmailBackend(**settings)
+
+        group_id = self.request.group_ref
+        approvers = get_admin_client().list_group_members(group_id, 0, 100)
+        for approver in approvers:
+            logger.info("Sending email to %s", approver.email)
+            send_mail(
+                subject=self._subject(),
+                message=self._plain_body(),
+                html_message=self._html_body(approver),
+                from_email=sender,
+                recipient_list=(approver.email,),
+                connection=backend,
+            )
+        backend.close()
+
+    def _subject(self):
+        return (
+            f"Catalog:Approval Order {self.request.id}: "
+            f"{self.request.requester_name}"
+        )
+
+    def _plain_body(self):
+        return (
+            "There is a Pinakes order requires your approval. "
+            f"Please visit {self._web_url()}/{self._approval_link()}."
+        )
+
+    def _html_body(self, approver):
+        content = self.request.request_context.content
+        params = {
+            "approval_id": self.request.id,
+            "approver_name": f"{approver.firstName} {approver.lastName}",
+            "orderer_email": self.request.user.email,
+            "requester_name": self.request.requester_name,
+            "order_id": content["order_id"],
+            "order_date": self.request.created_at.strftime("%m/%d/%Y"),
+            "order_time": self.request.created_at.strftime("%H:%M:%S"),
+            "product": content["product"],
+            "portfolio": content["portfolio"],
+            "platform": content["platform"],
+            "approve_link": self._approval_link(),
+            "web_url": self._web_url(),
+        }
+        email_template = read_text("pinakes.data", "email_template.html")
+        return string.Template(email_template).safe_substitute(**params)
+
+    def _web_url(self):
+        return self.request.request_context.context.get(
+            "http_host", "localhost"
+        )
+
+    def _approval_link(self):
+        return f"ui/catalog/approval/request?request={self.request.id}"

--- a/pinakes/main/approval/tests/services/test_email_notification.py
+++ b/pinakes/main/approval/tests/services/test_email_notification.py
@@ -1,0 +1,69 @@
+"""Test email notification"""
+from unittest.mock import Mock
+from unittest.mock import patch
+import pytest
+
+from pinakes.main.tests.factories import UserFactory
+from pinakes.main.approval.tests.factories import (
+    NotificationSettingFactory,
+    TemplateFactory,
+    WorkflowFactory,
+    RequestFactory,
+    RequestContextFactory,
+)
+from pinakes.main.approval.services.email_notification import EmailNotification
+
+
+@pytest.mark.django_db
+def test_email_notification(mocker):
+    """Test sending emails"""
+    email_settings = {
+        "host": "smtp.test.com",
+        "port": 123,
+        "security": "use_tls",
+        "from": "catalog@test.com",
+    }
+    content = {
+        "product": "feature product",
+        "portfolio": "feature portfolio",
+        "order_id": "1",
+        "platform": "feature AAP",
+        "params": {"key": "val"},
+    }
+    context = {"http_host": "test.com"}
+    request_context = RequestContextFactory(content=content, context=context)
+
+    group_ref = "group_uuid"
+    user = UserFactory(
+        email="user@test.com", first_name="wilma", last_name="Smith"
+    )
+    ns = NotificationSettingFactory(settings=email_settings)
+    template = TemplateFactory(process_method=ns)
+    workflow = WorkflowFactory(template=template)
+    request = RequestFactory(
+        workflow=workflow,
+        group_ref=group_ref,
+        request_context=request_context,
+        user=user,
+    )
+
+    admin = Mock()
+    approver = Mock(email="qa@test.com", firstName="Fred", lastName="Smith")
+    admin.list_group_members.return_value = [approver]
+    mocker.patch(
+        "pinakes.main.approval.services.email_notification.get_admin_client",
+        return_value=admin,
+    )
+
+    with patch(
+        "pinakes.main.approval.services.email_notification.send_mail"
+    ) as send_mail_call:
+        EmailNotification(request).process()
+        args = send_mail_call.call_args[1]
+        assert args["from_email"] == "catalog@test.com"
+        assert args["recipient_list"][0] == approver.email
+        assert args["connection"].host == email_settings["host"]
+        assert args["connection"].port == email_settings["port"]
+        assert args["connection"].use_tls is True
+        assert bool("</html>" in args["html_message"]) is True
+        assert bool("$" in args["html_message"]) is False

--- a/pinakes/main/approval/urls.py
+++ b/pinakes/main/approval/urls.py
@@ -14,7 +14,7 @@ from pinakes.main.approval.views import (
 urls_views = {}
 
 router = NestedDefaultRouter()
-notifications = router.register(
+router.register(
     "notifications_settings",
     NotificationSettingViewSet,
     basename="notificationsetting",

--- a/pinakes/main/catalog/services/submit_approval_request.py
+++ b/pinakes/main/catalog/services/submit_approval_request.py
@@ -18,10 +18,11 @@ logger = logging.getLogger("catalog")
 class SubmitApprovalRequest:
     """Submit a new approval request"""
 
-    def __init__(self, tag_resources, order):
+    def __init__(self, tag_resources, order, context={}):
         self.tag_resources = tag_resources
         self.order = order
         self.order_item = order.product
+        self.context = context
 
     def process(self):
         self.order.mark_approval_pending()
@@ -32,7 +33,7 @@ class SubmitApprovalRequest:
     def _submit_approval_request(self):
         try:
             request_body = self._create_approval_request_body()
-            svc = CreateRequest(request_body).process()
+            svc = CreateRequest(request_body, self.context).process()
 
             ApprovalRequest.objects.create(
                 approval_request_ref=str(svc.request.id),

--- a/pinakes/main/catalog/views.py
+++ b/pinakes/main/catalog/views.py
@@ -510,7 +510,16 @@ class OrderViewSet(
         order.update_message(ProgressMessage.Level.INFO, message)
 
         logger.info("Creating approval request for order id %d", order.id)
-        SubmitApprovalRequest(tag_resources, order).process()
+        if request and request.META:
+            http_host = (
+                request.META.get("HTTP_HOST")
+                or request.META.get("REMOTE_HOST")
+                or request.META.get("HTTP_ORIGIN")
+            )
+            context = {"http_host": http_host}
+        else:
+            context = {}
+        SubmitApprovalRequest(tag_resources, order, context).process()
 
         serializer = self.get_serializer(order)
         return Response(serializer.data)


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2842
https://issues.redhat.com/browse/SSP-2799
https://issues.redhat.com/browse/SSP-2610

Read the html email template and replace with runtime parameters. Fetch members of an approver group. Send customized email per approver.

Initially use the email template from the cloud version. Will need some modifications in a future PR.
Will need another PR to handle certificates for SSL connection to SMTP server.
Will need to decide what to send for plain email. 