### PR TITLE
Support overriding images/css and UI.tar

### DIFF
--- a/docs/MINIKUBE.md
+++ b/docs/MINIKUBE.md
@@ -85,3 +85,12 @@ If you are on Mac deleting the pods might not clear out the databases you might 
 minikube ssh
 sudo rm -rf /tmp/tmp/hostpath-provisioner/catalog/
 ```
+### Optionally overriding UI and images
+
+To override the UI tar file you can create a file in the following location
+   * ./overrides/ui/catalog-ui.tar.gz
+
+To override images and css you can store them in the following directories.
+  * ./overrides/pinakes
+  * ./overrides/approval
+  * ./overrides/keycloak

--- a/overrides/.gitignore
+++ b/overrides/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tools/minikube/scripts/server.sh
+++ b/tools/minikube/scripts/server.sh
@@ -25,10 +25,29 @@ echo -e "\e[32m >>> migration completed \e[97m"
 
 echo -e "\e[32m >>> Fetch UI tar\e[97m"
 
-curl -o ui.tar.xz -L https://github.com/ansible/pinakes-ui/releases/download/latest/catalog-ui.tar.gz
+if [[ -f overrides/ui/catalog-ui.tar.gz ]]
+then
+	echo "Overriding with local ui tar"
+	cp overrides/ui/catalog-ui.tar.gz .
+else
+	echo "Downloading ui tar"
+        curl -o catalog-ui.tar.gz -L https://github.com/ansible/pinakes-ui/releases/download/latest/catalog-ui.tar.gz
+fi
+
 rm -rf pinakes/ui/catalog
 mkdir -p pinakes/ui/catalog
-tar -xf ui.tar.xz --directory pinakes/ui/catalog
+tar -xf catalog-ui.tar.gz --directory pinakes/ui/catalog
+
+# Overlay the catalog and approval images from overrides
+if [[ -d overrides/pinakes ]]
+then
+	cp overrides/pinakes/* pinakes/ui/catalog/fonts
+fi
+
+if [[ -d overrides/approval ]]
+then
+	cp overrides/approval/* pinakes/ui/catalog/approval/fonts
+fi
 
 rm -rf "$PINAKES_STATIC_ROOT"
 

--- a/tools/minikube/scripts/start_pods.sh
+++ b/tools/minikube/scripts/start_pods.sh
@@ -53,9 +53,18 @@ if kubectl get configmap --namespace=catalog ansible-controller-env &>/dev/null;
 	kubectl delete --namespace=catalog configmap ansible-controller-env
 fi
 
-if ! kubectl get configmap --namespace=catalog keycloak-theme &>/dev/null; then
-     kubectl create configmap keycloak-theme --from-file=./tools/keycloak_setup/login_theme -n catalog
+# Override Keycloak image files
+tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
+cp ./tools/keycloak_setup/login_theme/* "$tmp_dir"
+if [[ -d ./overrides/keycloak ]]; then
+	cp ./overrides/keycloak/* "$tmp_dir"
 fi
+ 
+if ! kubectl get configmap --namespace=catalog keycloak-theme &>/dev/null; then
+     kubectl create configmap keycloak-theme --from-file="$tmp_dir" -n catalog
+fi
+
+rm -rf $tmp_dir
 
 kubectl create configmap \
     --namespace=catalog \


### PR DESCRIPTION
If an end user wants to put custom images and css they can do
that by providing files in the overrides directory.

The UI tar file goes into
 * ./overrides/ui/catalog-ui.tar.gz
The CSS/images can be stored in
 * ./overrides/pinakes
 * ./overrides/approval
 * ./overrides/keycloak