### PR TITLE
Move django-split-settings to dev-requirements.txt

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements.txt -r test-requirements.txt
+        python -m pip install -r requirements.txt -r test-requirements.txt -r dev-requirements.txt
 
     - name: Test with pytest
       run: |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+django-split-settings
 pylint
 pylint_django
 coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Django
 django-filter
 django-rq
-django-split-settings
 django-taggit
 djangorestframework
 drf-extensions


### PR DESCRIPTION
The Django split settings is only used when we are using
development settings (e.g. pytest, migration)