### PR TITLE
add https for keycloak in docker-compose stage

### DIFF
--- a/tools/docker/docker-compose.stage.yml
+++ b/tools/docker/docker-compose.stage.yml
@@ -4,7 +4,8 @@ x-environment:
   &catalog-env
   - PINAKES_CONTROLLER_TOKEN=${PINAKES_CONTROLLER_TOKEN}
   - PINAKES_CONTROLLER_URL=${PINAKES_CONTROLLER_URL:-https://10.0.153.78}
-  - PINAKES_KEYCLOAK_REALM_FRONTEND_URL=${PINAKES_KEYCLOAK_REALM_FRONTEND_URL:-http://localhost:8080/auth}
+  - PINAKES_KEYCLOAK_REALM_FRONTEND_URL=${PINAKES_KEYCLOAK_REALM_FRONTEND_URL:-https://localhost:9443/auth}
+  - PINAKES_KEYCLOAK_VERIFY_SSL=false
   - PINAKES_HTTPS_ENABLED=True
   - PINAKES_CSRF_TRUSTED_ORIGINS=${PINAKES_CSRF_TRUSTED_ORIGINS:-https://*,http://*}
   - PINAKES_STATIC_ROOT=/opt/app-root/src/staticfiles
@@ -15,10 +16,10 @@ x-environment:
   - PINAKES_SECRET_KEY=django-insecure-k8^atj4p3jj^zkb3=o(rhaysjzy_mr&#h(yl+ytj#f%@+er4&5
   - PINAKES_KEYCLOAK_USER=admin
   - PINAKES_KEYCLOAK_PASSWORD=admin
-  - PINAKES_KEYCLOAK_URL=http://keycloak-app:8080/auth
   - PINAKES_KEYCLOAK_REALM=pinakes
   - PINAKES_KEYCLOAK_CLIENT_ID=pinakes
   - PINAKES_KEYCLOAK_DISPLAY_NAME=PINAKES
+  - PINAKES_KEYCLOAK_URL=https://keycloak-app:8443/auth
   - PINAKES_KEYCLOAK_CLIENT_SECRET=${PINAKES_KEYCLOAK_CLIENT_SECRET:-SOMESECRETVALUE}
   - REDIRECT_URIS_STR=http://app:8000,http://app:8000/*,*
   - PINAKES_REDIS_HOST=redis
@@ -26,7 +27,6 @@ x-environment:
   - PINAKES_POSTGRES_USER=admin
   - PINAKES_POSTGRES_PASSWORD=admin
   - PINAKES_POSTGRES_SSL_MODE=disable
-  - PINAKES_KEYCLOAK_VERIFY_SSL=false
 
 services:
   frontend:
@@ -107,6 +107,7 @@ services:
     image: 'quay.io/keycloak/keycloak:15.0.2'
     ports:
       - '8080:8080'
+      - '9443:8443'
     depends_on:
       - 'postgres'
     environment:

--- a/tools/docker/scripts/keycloak-setup.sh
+++ b/tools/docker/scripts/keycloak-setup.sh
@@ -6,7 +6,7 @@ echo running > /startup/status
 
 while true;
 do echo "Waiting for keycloak service to come up...";
-    wget $PINAKES_KEYCLOAK_URL -q -T 1 -O /dev/null >/dev/null 2>/dev/null && break;
+    wget --no-check-certificate $PINAKES_KEYCLOAK_URL -q -T 1 -O /dev/null >/dev/null 2>/dev/null && break;
     sleep 3;
 done;
 echo "Service is up!"

--- a/tools/keycloak_setup/dev.yml
+++ b/tools/keycloak_setup/dev.yml
@@ -1,8 +1,8 @@
 ---
 - hosts: localhost
   vars:
-    seed_keycloak: true
     verify_keycloak_ssl: false
+    seed_keycloak: true
     seed_groups:
       - name: Information Technology - Sample
         clientRoles:


### PR DESCRIPTION
Fix variable name for keycloak setup. Upgrade version of keycloak setup collection. add ssl for keycloak and configure variable to use tls internally and externally in docker-compose stage environment

It's the same PR as #405 due to conflicts with the old ansible-catalog fork