### PR TITLE
[SSP-2849] Pass query_string to redirect

### DIFF
--- a/pinakes/main/auth/urls.py
+++ b/pinakes/main/auth/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
         "login/",
         RedirectView.as_view(
             pattern_name="social:begin",
+            query_string=True,
         ),
         name="login",
         kwargs={"backend": SOCIAL_AUTH_BACKEND},


### PR DESCRIPTION
We were missing the query_string setting when calling  the redirect.
This was preventing the next query parameter from getting passed to
the redirect

https://issues.redhat.com/browse/SSP-2849

https://docs.djangoproject.com/en/4.0/ref/class-based-views/base/#django.views.generic.base.RedirectView.query_string