### PR TITLE
[SSP-2854] Handle missing attributes in tower objects

### DIFF
--- a/pinakes/main/inventory/task_utils/service_plan_import.py
+++ b/pinakes/main/inventory/task_utils/service_plan_import.py
@@ -32,7 +32,12 @@ class ServicePlanImport:
         """Fetch the Service Plan"""
         logger.info(f"Fetching survey spec {slug}")
         for new_obj in self.tower.get(slug, ["name", "description", "spec"]):
-            self._handle(new_obj, service_offering_id, source_ref)
+            if new_obj["name"]:
+                self._handle(new_obj, service_offering_id, source_ref)
+            else:
+                logger.warning(
+                    "No survey spec found even though survey_spec is enabled"
+                )
 
     def _handle(self, data, service_offering_id, source_ref):
         """Convert the survey spec to DDF format and save it"""

--- a/pinakes/main/inventory/task_utils/spec_to_ddf.py
+++ b/pinakes/main/inventory/task_utils/spec_to_ddf.py
@@ -40,7 +40,7 @@ class SpecToDDF:
         result = {
             "label": field["question_name"],
             "name": field["variable"],
-            "helperText": field["question_description"],
+            "helperText": field.get("question_description", ""),
             "isRequired": field["required"],
         }
         result = {**result, **self.DDF_FIELD_TYPES[field["type"]]}
@@ -62,10 +62,13 @@ class SpecToDDF:
 
     def _getOptions(self, field):
         values = None
-        if isinstance(field["choices"], list):
-            values = field["choices"]
-        elif isinstance(field["choices"], str) and field["choices"] != "":
-            values = field["choices"].split("\n")
+        if "choices" in field:
+            if isinstance(field["choices"], list):
+                values = field["choices"]
+            elif isinstance(field["choices"], str) and field["choices"] != "":
+                values = field["choices"].split("\n")
+            else:
+                return []
         else:
             return []
 

--- a/pinakes/main/inventory/task_utils/tower_api.py
+++ b/pinakes/main/inventory/task_utils/tower_api.py
@@ -95,8 +95,12 @@ class TowerAPI:
             if self.attr_delimiter in attr:
                 data = payload
                 for key in attr.split(self.attr_delimiter):
-                    data = data[key]
+                    if key in data:
+                        data = data[key]
+                    else:
+                        data = None
+                        break
                 obj[attr] = data
             else:
-                obj[attr] = payload[attr]
+                obj[attr] = payload.get(attr, None)
         return obj

--- a/pinakes/main/inventory/tests/task_utils/test_service_offering_node_import.py
+++ b/pinakes/main/inventory/tests/task_utils/test_service_offering_node_import.py
@@ -20,12 +20,77 @@ from pinakes.main.inventory.models import (
 class TestServiceOfferingNodeImport:
     """Test ServiceOfferingNode import"""
 
+    OBJ_LIST1 = [
+        {
+            "url": "/api/v2/workflow_job_template_nodes/298/",
+            "id": 298,
+            "summary_fields.unified_job_template.unified_job_type": (
+                "workflow_job"
+            ),
+            "created": "2021-06-10T15:59:33.431827Z",
+            "modified": "2021-06-10T15:59:33.431850Z",
+            "inventory": 999,
+            "type": "workflow_job_template_node",
+            "workflow_job_template": 298,
+            "unified_job_template": 298,
+        },
+        {
+            "url": "/api/v2/workflow_job_template_nodes/290/",
+            "id": 290,
+            "summary_fields.unified_job_template.unified_job_type": "job",
+            "created": "2021-06-10T15:59:33.453817Z",
+            "modified": "2021-06-10T15:59:33.453851Z",
+            "inventory": 999,
+            "type": "workflow_job_template_node",
+            "workflow_job_template": 298,
+            "unified_job_template": 290,
+        },
+    ]
+    OBJ_LIST2 = [
+        {
+            "url": "/api/v2/workflow_job_template_nodes/298/",
+            "id": 298,
+            "summary_fields.unified_job_template.unified_job_type": None,
+            "created": "2021-06-10T15:59:33.431827Z",
+            "modified": "2021-06-10T15:59:33.431850Z",
+            "inventory": 999,
+            "type": "workflow_job_template_node",
+            "workflow_job_template": 298,
+            "unified_job_template": 298,
+        },
+        {
+            "url": "/api/v2/workflow_job_template_nodes/290/",
+            "id": 290,
+            "summary_fields.unified_job_template.unified_job_type": None,
+            "created": "2021-06-10T15:59:33.453817Z",
+            "modified": "2021-06-10T15:59:33.453851Z",
+            "inventory": 999,
+            "type": "workflow_job_template_node",
+            "workflow_job_template": 298,
+            "unified_job_template": 290,
+        },
+    ]
+
     @pytest.mark.django_db
-    def test_add(self):
+    @pytest.mark.parametrize(
+        "object_list, inventory_source_ref, expected",
+        [
+            (
+                OBJ_LIST1,
+                999,
+                2,
+            ),
+            (
+                OBJ_LIST2,
+                999,
+                0,
+            ),
+        ],
+    )
+    def test_add(self, object_list, inventory_source_ref, expected):
         """Test adding new objects."""
         tenant = TenantFactory()
         source = SourceFactory()
-        inventory_source_ref = "999"
         inventory = ServiceInventoryFactory(
             tenant=tenant, source=source, source_ref=inventory_source_ref
         )
@@ -33,35 +98,9 @@ class TestServiceOfferingNodeImport:
             tenant=tenant, source=source, source_ref="298"
         )
         tower_mock = Mock()
-        objs = [
-            {
-                "url": "/api/v2/workflow_job_template_nodes/298/",
-                "id": 298,
-                "summary_fields.unified_job_template.unified_job_type": (
-                    "workflow_job"
-                ),
-                "created": "2021-06-10T15:59:33.431827Z",
-                "modified": "2021-06-10T15:59:33.431850Z",
-                "inventory": int(inventory_source_ref),
-                "type": "workflow_job_template_node",
-                "workflow_job_template": 298,
-                "unified_job_template": 298,
-            },
-            {
-                "url": "/api/v2/workflow_job_template_nodes/290/",
-                "id": 290,
-                "summary_fields.unified_job_template.unified_job_type": "job",
-                "created": "2021-06-10T15:59:33.453817Z",
-                "modified": "2021-06-10T15:59:33.453851Z",
-                "inventory": int(inventory_source_ref),
-                "type": "workflow_job_template_node",
-                "workflow_job_template": 298,
-                "unified_job_template": 290,
-            },
-        ]
 
         def fake_method(*args, **_kwarg):
-            for i in objs:
+            for i in object_list:
                 yield i
 
         tower_mock.get.side_effect = fake_method
@@ -81,8 +120,8 @@ class TestServiceOfferingNodeImport:
             service_offering_import_mock,
         )
         soni.process()
-        assert (ServiceOfferingNode.objects.all().count()) == 2
-        assert (soni.get_stats()["adds"]) == 2
+        assert (ServiceOfferingNode.objects.all().count()) == expected
+        assert (soni.get_stats()["adds"]) == expected
 
     @pytest.mark.django_db
     def test_deletes(self):

--- a/pinakes/main/inventory/tests/task_utils/test_spec_to_ddf.py
+++ b/pinakes/main/inventory/tests/task_utils/test_spec_to_ddf.py
@@ -97,14 +97,11 @@ class TestSpecToDDF:
         "spec": [
           {
                 "question_name": "Password",
-                "question_description": "Please enter your password",
+                "question_description": "Enter your password",
                 "required": true,
                 "type": "password",
                 "variable": "blank_password",
-                "min": 0,
-                "max": 32,
                 "default": "$encrypted$",
-                "choices": "",
                 "new_question": true
             }
            ]
@@ -191,6 +188,24 @@ class TestSpecToDDF:
            ]
     }
     """
+
+    testdata10 = """
+    {
+        "name": "",
+        "description": "",
+        "spec": [
+          {
+                "question_name": "Password",
+                "question_description": "Enter your password",
+                "required": true,
+                "type": "password",
+                "variable": "blank_password",
+                "default": "$encrypted$",
+                "new_question": true
+            }
+           ]
+    }
+    """
     result1 = {"component": "select-field"}
     result2 = {"dataType": "integer"}
     result3 = {"dataType": "float"}
@@ -200,6 +215,7 @@ class TestSpecToDDF:
     result7 = {"component": "select-field"}
     result8 = {"component": "select-field"}
     result9 = {"component": "select-field"}
+    result10 = {"component": "text-field"}
 
     @pytest.mark.parametrize(
         "test_input,expected",
@@ -213,6 +229,7 @@ class TestSpecToDDF:
             (testdata7, result7),
             (testdata8, result8),
             (testdata9, result9),
+            (testdata10, result10),
         ],
     )
     def test_conversion(self, test_input, expected):

--- a/pinakes/main/inventory/tests/task_utils/test_tower_api.py
+++ b/pinakes/main/inventory/tests/task_utils/test_tower_api.py
@@ -76,6 +76,7 @@ class TestTowerAPI:
             "name": "abc",
             "description": "desc1",
             "related": {"inventory": 2},
+            "summary": {"info": {"version": "2.0"}},
         }
         tower_api = TowerAPI(
             "https://www.example.com", "gobbledegook", "false"
@@ -89,9 +90,15 @@ class TestTowerAPI:
         names = []
         for obj in tower_api.get(
             "/api/v2/job_templates/1/",
-            ["name", "description", "related.inventory"],
+            [
+                "name",
+                "description",
+                "related.inventory",
+                "summary.info.missing",
+            ],
         ):
             names.append(obj["name"])
+            assert obj["summary.info.missing"] is None
 
         assert (names) == ["abc"]
 


### PR DESCRIPTION
Some of the attributes in Survey Spec seem to optional and not mandatory.
This was causing KeyErrors for the 
* choices
* question_description
* unified_job_template
https://issues.redhat.com/browse/SSP-2854