### PR TITLE
Log social auth http error detail

### DIFF
--- a/pinakes/settings/defaults.py
+++ b/pinakes/settings/defaults.py
@@ -274,6 +274,15 @@ LOGGING = {
             "level": LOG_LEVEL,
             "propagate": False,
         },
+        "django.db.backends": {
+            "handlers": ["console"],
+            "level": LOG_LEVEL,
+        },
+        "pinakes": {
+            "handlers": ["console"],
+            "level": LOG_LEVEL,
+            "propagate": False,
+        },
         "approval": {
             "handlers": ["console"],
             "level": LOG_LEVEL,
@@ -293,10 +302,6 @@ LOGGING = {
             "handlers": ["rq_console"],
             "level": LOG_LEVEL,
             "propagate": False,
-        },
-        "django.db.backends": {
-            "handlers": ["console"],
-            "level": LOG_LEVEL,
         },
     },
 }


### PR DESCRIPTION
During social auth login, when Keycloak returns HTTP error in response
to a back channel request it is hard to determine actual error reason,
because response body is not logged.
This PR fixes the problem by logging HTTP response error details.

Example:

```
[2022-04-07 16:02:10,412] [59066] [ERROR] pinakes keycloak_oidc 139865600587328 HTTPError: POST http://localhost:8080/auth/realms/pinakes/protocol/openid-connect/token 401 Unauthorized [unauthorized_client] Invalid client secret
```