### PR TITLE
[SSP-2838] Action comments are optional

### DIFF
--- a/pinakes/main/approval/serializers.py
+++ b/pinakes/main/approval/serializers.py
@@ -148,6 +148,11 @@ class ActionSerializer(serializers.ModelSerializer):
         default="",
     )
 
+    comments = serializers.CharField(
+        help_text="Comments for the action",
+        default="",
+    )
+
     class Meta:
         model = Action
         fields = (

--- a/pinakes/main/approval/tests/functional/test_request_end_points.py
+++ b/pinakes/main/approval/tests/functional/test_request_end_points.py
@@ -174,6 +174,23 @@ def test_create_action(api_request, mocker):
 
 
 @pytest.mark.django_db
+def test_create_action_no_comments(api_request, mocker):
+    has_permission = mocker.spy(ActionPermission, "has_permission")
+    mocker.patch.object(SendEvent, "process")
+    request = RequestFactory(state="notified")
+    response = api_request(
+        "post",
+        "approval:request-action-list",
+        request.id,
+        {
+            "operation": "approve",
+        },
+    )
+    assert response.status_code == 201
+    has_permission.assert_called_once()
+
+
+@pytest.mark.django_db
 def test_retrieve_action(api_request, mocker):
     has_permission = mocker.spy(ActionPermission, "has_object_permission")
     request = RequestFactory()


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2838

Comments for Actions in model are not required, but somehow the serializer makes it mandatory. The fix is to amend the serializer. 