### PR TITLE
[SSP-2843] Enable email notification

### DIFF
--- a/pinakes/main/approval/services/update_request.py
+++ b/pinakes/main/approval/services/update_request.py
@@ -10,6 +10,9 @@ from pinakes.main.approval.services.send_event import (
 from pinakes.main.approval.services.create_action import (
     CreateAction,
 )
+from pinakes.main.approval.services.email_notification import (
+    EmailNotification,
+)
 from pinakes.main.approval import validations
 
 logger = logging.getLogger("approval")
@@ -185,10 +188,14 @@ class UpdateRequest:
         validations.runtime_validate_group(self.request)
 
     def _notify_request(self):
-        # notify if this is an internal processing
-        CreateAction(
-            self.request, {"operation": Action.Operation.NOTIFY, "user": None}
-        ).process()
+        template = self.request.workflow.template
+        if template.process_method:
+            EmailNotification(self.request).process()
+        else:
+            # notify if this is an internal processing
+            CreateAction(
+                self.request, {"operation": Action.Operation.NOTIFY, "user": None}
+            ).process()
 
     def _approve_request(self):
         # auto approve the request

--- a/pinakes/main/approval/validations.py
+++ b/pinakes/main/approval/validations.py
@@ -1,5 +1,7 @@
 """Validation functions for approval groups"""
 
+import logging
+from django.utils.translation import gettext_lazy as _
 from pinakes.main.approval.exceptions import (
     DuplicatedUuidException,
     NoAppoverRoleException,
@@ -10,6 +12,8 @@ from pinakes.main.approval.models import Action
 from pinakes.main.approval.services.create_action import (
     CreateAction,
 )
+
+logger = logging.getLogger("approval")
 
 
 def validate_approver_groups(group_refs, raise_error=True):
@@ -47,12 +51,17 @@ def runtime_validate_group(request):
     group = Group.objects.filter(id=request.group_ref).first()
 
     if not group:
-        _error_action(request, f"Group id {request.group_ref} does not exist")
+        logger.error("Group id %s does not exist", request.group_ref)
+        _error_action(
+            request, _("Group id {} does not exist").format(request.group_ref)
+        )
         return False
 
     if not _can_approve(group):
+        logger.error("Group %s does not have approver role", group.name)
         _error_action(
-            request, f"Group {group.name} does not have approver role"
+            request,
+            _("Group {} does not have approver role").format(group.name),
         )
         return False
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2843

Send email notifications during the approval request processing. It is backward compatible. System will auto-notify if no email settings are configured.
Re-enable previously skipped tests due to lacking of notification.