### PR TITLE
Use correct workflow job templates API endpoint.

### DIFF
--- a/pinakes/main/inventory/services/start_tower_job.py
+++ b/pinakes/main/inventory/services/start_tower_job.py
@@ -22,7 +22,8 @@ class StartTowerJob:
         """Start background task and return the job id"""
         if self.service_offering.kind == OfferingKind.WORKFLOW:
             slug = (
-                f"/api/v2/workflows/{self.service_offering.source_ref}/launch/"
+                "/api/v2/workflow_job_templates/"
+                f"{self.service_offering.source_ref}/launch/"
             )
         else:
             slug = (

--- a/pinakes/main/inventory/tests/services/test_start_tower_job.py
+++ b/pinakes/main/inventory/tests/services/test_start_tower_job.py
@@ -28,9 +28,9 @@ def test_starting_a_workflow(mock):
     assert obj.job_id() == job_id
 
     assert mock.call_count == 1
-    assert (
-        mock.call_args.args[1]
-        == f"/api/v2/workflows/{service_offering.source_ref}/launch/"
+    assert mock.call_args.args[1] == (
+        "/api/v2/workflow_job_templates/"
+        f"{service_offering.source_ref}/launch/"
     )
     assert mock.call_args.args[2] == {"extra_vars": "abc"}
 


### PR DESCRIPTION
An incorrect API endpoint for launching workflow job templates is used, which causes orders for products based on workflow templates to fail.

This patch corrects that and updates the tests to suit.