### PR TITLE
Add gitter info to readme and contribution docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Reporting Issues
 
 If you're experiencing a problem that you feel is a bug in Pinakes or have ideas for improving Pinakes, we encourage you to open an issue and share your feedback.
 
+You can also contact us in real-time on gitter.im in our [ansible-pinakes](https://gitter.im/ansible-pinakes/community) channel.
+
 
 Code of Conduct
 ---------------

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -48,3 +48,5 @@ All submitted PRs will have the linter and unit tests run against them via githu
 ## Reporting Issues
 
 We welcome your feedback, and encourage you to file an issue when you run into a problem.
+
+You can also contact us in real-time on gitter.im in our [ansible-pinakes](https://gitter.im/ansible-pinakes/community) channel.


### PR DESCRIPTION
Added a link to our new ansible-pinakes gitter channel to the README and CONTRIBUTING docs. Will also update the wiki.