### PR TITLE
Send emails in a queued job

### DIFF
--- a/pinakes/main/approval/services/process_root_request.py
+++ b/pinakes/main/approval/services/process_root_request.py
@@ -65,6 +65,7 @@ class ProcessRootRequest:
             group_ref=group_uuid,
             group_name=group_name,
         )
+        leaf_request.refresh_from_db()
 
     def _update_root_group_name(self):
         sub_groups = self.request.subrequests.order_by("id").values(

--- a/pinakes/main/approval/services/update_request.py
+++ b/pinakes/main/approval/services/update_request.py
@@ -226,7 +226,7 @@ class UpdateRequest:
         return not self._external_processable()
 
     def _external_processable(self):
-        return (
+        return bool(
             self.request.workflow
             and self.request.workflow.template.process_method
         )

--- a/pinakes/main/approval/tasks.py
+++ b/pinakes/main/approval/tasks.py
@@ -7,12 +7,14 @@ from pinakes.main.approval.services.create_action import (
 from pinakes.main.approval.services.process_root_request import (
     ProcessRootRequest,
 )
+from pinakes.main.approval.services.email_notification import EmailNotification
 from pinakes.main.approval.models import Action
 
 logger = logging.getLogger("approval")
 
 
 def process_root_task(root_id, workflow_ids):
+    """Process root request"""
     job = get_current_job()
     try:
         logger.info(
@@ -35,6 +37,21 @@ def start_request_task(request_id):
         CreateAction(
             request_id, {"operation": Action.Operation.START}
         ).process()
+    except Exception as exc:
+        logger.error("Job %s failed with exception %s", job.id, str(exc))
+        raise
+
+
+def email_task(request_id):
+    """Send emails to approvers"""
+    job = get_current_job()
+    try:
+        logger.info(
+            "Job %s: Sending email notification for request %d",
+            job.id,
+            request_id,
+        )
+        EmailNotification(request_id).send_emails()
     except Exception as exc:
         logger.error("Job %s failed with exception %s", job.id, str(exc))
         raise

--- a/pinakes/main/approval/tests/services/test_email_notification.py
+++ b/pinakes/main/approval/tests/services/test_email_notification.py
@@ -62,7 +62,7 @@ def test_email_notification(mocker):
     with patch(
         "pinakes.main.approval.services.email_notification.send_mail"
     ) as send_mail_call:
-        EmailNotification(request).process()
+        EmailNotification(request).send_emails()
         args = send_mail_call.call_args[1]
         assert args["from_email"] == "catalog@test.com"
         assert args["recipient_list"][0] == approver.email
@@ -78,5 +78,5 @@ def test_email_notification(mocker):
         "pinakes.main.approval.services.email_notification.send_mail"
     ) as send_mail_call:
         send_mail_call.side_effect = Exception()
-        EmailNotification(request).process()
+        EmailNotification(request).send_emails()
         assert request.state == "failed"

--- a/pinakes/main/approval/tests/services/test_process_root_request.py
+++ b/pinakes/main/approval/tests/services/test_process_root_request.py
@@ -43,6 +43,10 @@ def test_process_request_one_workflow_one_group(mocker):
         "pinakes.main.common.tasks.add_group_permissions",
         return_value=None,
     )
+    validations = mocker.patch(
+        "pinakes.main.approval.validations.runtime_validate_group",
+        return_value=True,
+    )
 
     workflow = WorkflowFactory(group_refs=({"name": "n1", "uuid": "u1"},))
     service = _prepare_service(mocker, [workflow.id])
@@ -51,6 +55,7 @@ def test_process_request_one_workflow_one_group(mocker):
         request, state="notified", group_name="n1", workflow=workflow
     )
     assert add_permissions.call_count == 1
+    assert validations.call_count == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
A follow-up to #471 
With the existing logic for updating a request, the request state changes from pending, notified, and then started, which is wrong.
Move the sending email logic to a queued job, thus the request state changes from pending to started. The background task then changes the state to notified.