### PR TITLE
Fix service offering with none related inventory

### DIFF
--- a/pinakes/main/inventory/task_utils/service_offering_import.py
+++ b/pinakes/main/inventory/task_utils/service_offering_import.py
@@ -74,7 +74,11 @@ class ServiceOfferingImport:
     def _handle_obj(self, new_obj, kind):
         """Handle an object based on kind of object job template or workflow"""
         source_ref = str(new_obj["id"])
-        inventory = self._get_inventory(new_obj["related.inventory"])
+        inventory = (
+            self._get_inventory(new_obj["related.inventory"])
+            if new_obj.get("related.inventory", None)
+            else None
+        )
         if source_ref in self.old_objects.keys():
             info = self.old_objects[source_ref]
             self._update_db_obj(info, new_obj, source_ref, inventory)


### PR DESCRIPTION
Fix refresh error when service offering's related inventory is none.

```
[2022-04-18 20:58:36,289] [212] [ERROR] refresh_inventory 140240078336256 Refresh failed: expected string or bytes-like object
[2022-04-18 20:58:36,317] [212] [ERROR] refresh_inventory 140240078336256 Traceback (most recent call last):
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/refresh_inventory.py", line 64, in process
    soi.process()
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/service_offering_import.py", line 56, in process
    self._process_job_templates()
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/service_offering_import.py", line 100, in _process_job_templates
    self._handle_obj(new_obj, OfferingKind.JOB_TEMPLATE)
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/service_offering_import.py", line 77, in _handle_obj
    inventory = self._get_inventory(new_obj["related.inventory"])
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/service_offering_import.py", line 89, in _get_inventory
    result = re.search(r"\/api\/v2\/inventories\/(\w*)\/", url)
  File "/usr/lib64/python3.9/re.py", line 201, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object
```