### PR TITLE
Fix KeyError in source_ref_to_id function

### DIFF
--- a/pinakes/main/inventory/task_utils/service_inventory_import.py
+++ b/pinakes/main/inventory/task_utils/service_inventory_import.py
@@ -2,8 +2,11 @@
     object from Ansible Tower. It handles adds, updates
     and deletes.
 """
+import logging
 import dateutil.parser
 from pinakes.main.inventory.models import ServiceInventory
+
+logger = logging.getLogger("inventory")
 
 
 class ServiceInventoryImport:
@@ -19,7 +22,13 @@ class ServiceInventoryImport:
     def source_ref_to_id(self, source_ref):
         """Given a Source Ref, get the ID of the object
         from the local database."""
-        return self.service_inventory_objects[source_ref]
+        source_id = self.service_inventory_objects.get(source_ref, None)
+        if source_id is None:
+            logger.warning(
+                f"Source {source_ref} is not found in service inventory"
+            )
+
+        return source_id
 
     def get_stats(self):
         """Get the stats of the process, the number of adds,

--- a/pinakes/main/inventory/task_utils/service_offering_import.py
+++ b/pinakes/main/inventory/task_utils/service_offering_import.py
@@ -44,7 +44,13 @@ class ServiceOfferingImport:
 
     def source_ref_to_id(self, source_ref):
         """Convert id from tower to id in local database."""
-        return self.service_offering_objects[source_ref]
+        source_id = self.service_offering_objects.get(source_ref, None)
+        if source_id is None:
+            logger.warning(
+                f"Source {source_ref} is not found in service offering"
+            )
+
+        return source_id
 
     def get_stats(self):
         """Get the adds/updates/deletes for this object."""


### PR DESCRIPTION
Fix KeyError by logging a warning message in `source_ref_to_id` function:

```
[2022-04-18 22:51:12,788] [176] [ERROR] refresh_inventory 139922874429696 Refresh failed: 10
[2022-04-18 22:51:12,789] [176] [ERROR] refresh_inventory 139922874429696 Traceback (most recent call last):
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/refresh_inventory.py", line 70, in process
    son.process()
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/service_offering_node_import.py", line 42, in process
    self._process_workflow_job_template_nodes()
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/service_offering_node_import.py", line 79, in _process_workflow_job_template_nodes
    self._handle_obj(new_obj)
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/service_offering_node_import.py", line 55, in _handle_obj
    inventory = self._get_inventory(new_obj["inventory"])
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/service_offering_node_import.py", line 66, in _get_inventory
    return self.inventory.source_ref_to_id(value)
  File "/opt/app-root/src/pinakes/main/inventory/task_utils/service_inventory_import.py", line 22, in source_ref_to_id
    return self.service_inventory_objects[source_ref]
KeyError: 10
```