### PR TITLE
[SSP-2807] User capabilities basic implementation

### DIFF
--- a/pinakes/common/auth/keycloak_django/views.py
+++ b/pinakes/common/auth/keycloak_django/views.py
@@ -1,25 +1,42 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, ClassVar, Type, List
 
 from django.db.models import QuerySet
 from rest_framework.request import Request
 from rest_framework.views import APIView
+from rest_framework.permissions import BasePermission
+
+from pinakes.common.auth.keycloak_django.permissions import (
+    BaseKeycloakPermission,
+)
 
 
 ScopeQuerysetFn = Callable[[Request, APIView, QuerySet], QuerySet]
 
 
-class PermissionQuerySetMixin:
+class KeycloakPermissionMixin:
+
+    keycloak_permission: ClassVar[Type[BaseKeycloakPermission]]
+
+    def get_keycloak_permission(self) -> BaseKeycloakPermission:
+        return self.keycloak_permission()
+
+    def get_permissions(self) -> List[BasePermission]:
+        permissions = super().get_permissions()
+        keycloak_permission = self.get_keycloak_permission()
+        return [*permissions, keycloak_permission]
+
     def get_queryset(self) -> QuerySet:
         qs = super().get_queryset()
         swagger_view = getattr(self, "swagger_fake_view", False)
         if swagger_view:
             return qs
-        for permission in self.get_permissions():
-            scope_queryset_fn: ScopeQuerysetFn = getattr(
-                permission, "scope_queryset", None
-            )
-            if scope_queryset_fn:
-                qs = scope_queryset_fn(self.request, self, qs)
+
+        permission = self.get_keycloak_permission()
+        scope_queryset_fn: ScopeQuerysetFn = getattr(
+            permission, "scope_queryset", None
+        )
+        if scope_queryset_fn:
+            qs = scope_queryset_fn(self.request, self, qs)
         return qs

--- a/pinakes/common/fields.py
+++ b/pinakes/common/fields.py
@@ -1,0 +1,37 @@
+from typing import Dict
+
+from rest_framework import serializers
+
+
+class UserCapabilitiesField(serializers.ReadOnlyField):
+    def __init__(self, **kwargs):
+        kwargs["source"] = "*"
+        super().__init__(**kwargs)
+
+    def to_representation(self, value) -> Dict[str, bool]:
+        request = self.context["request"]
+        view = self.context["view"]
+
+        keycloak_permission = view.get_keycloak_permission()
+        permissions = keycloak_permission.get_user_capabilities(
+            request, view, value
+        )
+        return permissions
+
+
+class MetadataSerializer(serializers.Serializer):
+
+    user_capabilities = UserCapabilitiesField()
+
+    def __init__(self, skip_user_capabilities=False, **kwargs):
+        kwargs["source"] = "*"
+        kwargs["read_only"] = True
+        super().__init__(**kwargs)
+
+        if skip_user_capabilities:
+            self.fields.pop("user_capabilities", None)
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data.update(getattr(instance, self.field_name, {}))
+        return data

--- a/pinakes/main/approval/permissions.py
+++ b/pinakes/main/approval/permissions.py
@@ -76,14 +76,17 @@ class RequestPermission(BaseKeycloakPermission):
     """Permission class for Request view"""
 
     access_policies = {
+        "create": KeycloakPolicy("", KeycloakPolicy.Type.WILDCARD),
         "list": KeycloakPolicy("read", KeycloakPolicy.Type.QUERYSET),
         "retrieve": KeycloakPolicy("read", KeycloakPolicy.Type.OBJECT),
         "content": KeycloakPolicy("read", KeycloakPolicy.Type.OBJECT),
     }
 
     def perform_check_permission(
-        self, permission: str, http_request: HttpRequest, _view: Any
+        self, permission: str, http_request: HttpRequest, view: Any
     ) -> bool:
+        if view.action == "create":
+            return True
         return check_wildcard_permission(
             Request.keycloak_type(),
             permission,

--- a/pinakes/main/catalog/serializers.py
+++ b/pinakes/main/catalog/serializers.py
@@ -2,6 +2,7 @@
 from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
+from pinakes.common.fields import MetadataSerializer
 from pinakes.main.models import Tenant, Image
 from pinakes.main.common.models import Group
 from pinakes.main.catalog.models import (
@@ -36,10 +37,8 @@ class PortfolioSerializer(serializers.ModelSerializer):
         "get_icon_url", allow_null=True
     )
 
-    metadata = serializers.JSONField(
-        read_only=True,
-        help_text="JSON Metadata about the portfolio",
-        default={},
+    metadata = MetadataSerializer(
+        help_text="JSON Metadata about the portfolio"
     )
 
     class Meta:
@@ -95,7 +94,7 @@ class CopyPortfolioSerializer(serializers.Serializer):
     )
 
 
-class PortfolioItemSerializer(serializers.ModelSerializer):
+class PortfolioItemSerializerBase(serializers.ModelSerializer):
     """PortfolioItem which maps to a Controller Job Template
     via the service_offering_ref"""
 
@@ -103,10 +102,9 @@ class PortfolioItemSerializer(serializers.ModelSerializer):
         "get_icon_url", allow_null=True
     )
 
-    metadata = serializers.JSONField(
-        read_only=True,
+    metadata = MetadataSerializer(
+        skip_user_capabilities=True,
         help_text="JSON Metadata about the portfolio item",
-        default={},
     )
 
     class Meta:
@@ -137,6 +135,12 @@ class PortfolioItemSerializer(serializers.ModelSerializer):
         )
 
 
+class PortfolioItemSerializer(PortfolioItemSerializerBase):
+    metadata = MetadataSerializer(
+        help_text="JSON Metadata about the portfolio item"
+    )
+
+
 class CopyPortfolioItemSerializer(serializers.Serializer):
     """Parameters to copy a portfolio item"""
 
@@ -149,26 +153,25 @@ class CopyPortfolioItemSerializer(serializers.Serializer):
     )
 
 
-class OrderItemFields:
-    FIELDS = (
-        "id",
-        "name",
-        "count",
-        "service_parameters",
-        "provider_control_parameters",
-        "state",
-        "portfolio_item",
-        "order",
-        "service_instance_ref",
-        "inventory_service_plan_ref",
-        "inventory_task_ref",
-        "external_url",
-        "owner",
-        "order_request_sent_at",
-        "created_at",
-        "updated_at",
-        "completed_at",
-    )
+ORDER_ITEM_FIELDS = (
+    "id",
+    "name",
+    "count",
+    "service_parameters",
+    "provider_control_parameters",
+    "state",
+    "portfolio_item",
+    "order",
+    "service_instance_ref",
+    "inventory_service_plan_ref",
+    "inventory_task_ref",
+    "external_url",
+    "owner",
+    "order_request_sent_at",
+    "created_at",
+    "updated_at",
+    "completed_at",
+)
 
 
 class OrderItemExtraSerializer(serializers.Serializer):
@@ -177,23 +180,28 @@ class OrderItemExtraSerializer(serializers.Serializer):
     available only when query parameter extra=true
     """
 
-    portfolio_item = PortfolioItemSerializer(many=False)
+    portfolio_item = PortfolioItemSerializerBase(many=False)
 
 
-class OrderItemSerializer(serializers.ModelSerializer):
+class OrderItemSerializerBase(serializers.ModelSerializer):
     """OrderItem which keeps track of an execution of Portfolio Item"""
 
     owner = serializers.ReadOnlyField()
     extra_data = serializers.SerializerMethodField(
         "get_extra_data", read_only=True, allow_null=True
     )
+    metadata = MetadataSerializer(
+        skip_user_capabilities=True,
+        help_text="Order item metadata",
+    )
 
     class Meta:
         model = OrderItem
         fields = (
-            *OrderItemFields.FIELDS,
+            *ORDER_ITEM_FIELDS,
             "artifacts",
             "extra_data",
+            "metadata",
         )
         read_only_fields = ("created_at", "updated_at", "order", "name")
         extra_kwargs = {
@@ -220,12 +228,16 @@ class OrderItemSerializer(serializers.ModelSerializer):
         )
 
 
+class OrderItemSerializer(OrderItemSerializerBase):
+    metadata = MetadataSerializer(help_text="Order item metadata")
+
+
 class OrderItemDocSerializer(serializers.ModelSerializer):
     """Workaround for OrderItem list params in openapi spec"""
 
     class Meta:
         model = OrderItem
-        fields = (*OrderItemFields.FIELDS,)
+        fields = ORDER_ITEM_FIELDS
         read_only_fields = (
             "created_at",
             "updated_at",
@@ -241,7 +253,7 @@ class OrderExtraSerializer(serializers.Serializer):
     available only when query parameter extra=true
     """
 
-    order_items = OrderItemSerializer(many=True)
+    order_items = OrderItemSerializerBase(many=True)
 
 
 class OrderSerializer(serializers.ModelSerializer):
@@ -252,6 +264,8 @@ class OrderSerializer(serializers.ModelSerializer):
     extra_data = serializers.SerializerMethodField(
         "get_extra_data", allow_null=True, read_only=True
     )
+
+    metadata = MetadataSerializer(help_text="Order metadata")
 
     class Meta:
         model = Order
@@ -264,6 +278,7 @@ class OrderSerializer(serializers.ModelSerializer):
             "updated_at",
             "completed_at",
             "extra_data",
+            "metadata",
         )
         read_only_fields = ("created_at", "updated_at")
         extra_kwargs = {

--- a/pinakes/main/catalog/tests/functional/test_order_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_order_end_points.py
@@ -18,6 +18,14 @@ from pinakes.main.inventory.tests.factories import (
 )
 
 
+EXPECTED_USER_CAPABILITIES = {
+    "retrieve": True,
+    "destroy": True,
+    "cancel": True,
+    "submit": True,
+}
+
+
 @pytest.mark.django_db
 def test_order_list(api_request, mocker):
     """Get List of Orders"""
@@ -29,7 +37,12 @@ def test_order_list(api_request, mocker):
     content = json.loads(response.content)
 
     assert content["count"] == 1
-    assert content["results"][0]["extra_data"] is None
+    results = content["results"]
+    assert results[0]["extra_data"] is None
+    assert (
+        results[0]["metadata"]["user_capabilities"]
+        == EXPECTED_USER_CAPABILITIES
+    )
 
     scope_queryset.assert_called_once()
 
@@ -63,7 +76,10 @@ def test_order_retrieve(api_request, mocker):
     assert content["id"] == order.id
     assert content["owner"] == order.owner
     assert content["extra_data"] is None
-    check_object_permission.assert_called_once()
+    assert (
+        content["metadata"]["user_capabilities"] == EXPECTED_USER_CAPABILITIES
+    )
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -79,11 +95,14 @@ def test_order_retrieve_extra(api_request, mocker):
     )
 
     assert response.status_code == 200
-    content = json.loads(response.content)
-    assert content["id"] == order.id
-    assert content["owner"] == order.owner
-    assert content["extra_data"]["order_items"][0]["name"] == order_item.name
-    check_object_permission.assert_called_once()
+    result = json.loads(response.content)
+    assert result["id"] == order.id
+    assert result["owner"] == order.owner
+
+    order_item_result = result["extra_data"]["order_items"][0]
+    assert order_item_result["name"] == order_item.name
+    assert "user_capabilities" not in order_item_result
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -96,7 +115,7 @@ def test_order_delete(api_request, mocker):
     response = api_request("delete", "catalog:order-detail", order.id)
 
     assert response.status_code == 204
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -124,7 +143,7 @@ def test_order_submit(api_request, mocker):
     content = json.loads(response.content)
     assert content["state"] == "Approval Pending"
     assert content["state"] == order.state
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -146,7 +165,7 @@ def test_order_submit_without_service_offering(api_request, mocker):
         content["detail"] == f"Portfolio item {portfolio_item.id} does not"
         " have related service offering"
     )
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -167,7 +186,7 @@ def test_order_submit_without_order_item(api_request, mocker):
         content["detail"]
         == f"Order {order.id} does not have related order items"
     )
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -187,7 +206,7 @@ def test_order_cancel(api_request, mocker):
 
     assert response.status_code == 204
     assert order.state == "Canceled"
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db

--- a/pinakes/main/catalog/tests/functional/test_order_item_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_order_item_end_points.py
@@ -10,6 +10,13 @@ from pinakes.main.catalog.tests.factories import (
 
 # FIXME(cutwater): Add unit tests for `catalog:orderitem-list` endpoint.
 
+EXPECTED_USER_CAPABILITIES = {
+    "retrieve": True,
+    "update": True,
+    "partial_update": True,
+    "destroy": True,
+}
+
 
 @pytest.mark.django_db
 def test_order_item_retrieve(api_request, mocker):
@@ -25,6 +32,9 @@ def test_order_item_retrieve(api_request, mocker):
     assert content["id"] == order_item.id
     assert content["owner"] == order_item.owner
     assert content["extra_data"] is None
+    assert (
+        content["metadata"]["user_capabilities"] == EXPECTED_USER_CAPABILITIES
+    )
 
     has_object_permission.assert_called_once()
 
@@ -50,6 +60,9 @@ def test_order_item_retrieve_extra(api_request, mocker):
     assert content["owner"] == order_item.owner
     assert (
         content["extra_data"]["portfolio_item"]["name"] == portfolio_item.name
+    )
+    assert (
+        content["metadata"]["user_capabilities"] == EXPECTED_USER_CAPABILITIES
     )
     has_object_permission.assert_called_once()
 

--- a/pinakes/main/catalog/tests/functional/test_portfolio_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_portfolio_end_points.py
@@ -33,6 +33,22 @@ from pinakes.common.auth.keycloak_django.utils import (
 )
 
 
+EXPECTED_USER_CAPABILITIES = {
+    "retrieve": True,
+    "update": True,
+    "partial_update": True,
+    "destroy": True,
+    "tags": True,
+    "tag": True,
+    "untag": True,
+    "share": True,
+    "unshare": True,
+    "share_info": True,
+    "icon": True,
+    "copy": True,
+}
+
+
 @pytest.mark.django_db
 def test_portfolio_list(api_request, mocker):
     """Get List of Portfolios"""
@@ -43,8 +59,13 @@ def test_portfolio_list(api_request, mocker):
 
     assert response.status_code == 200
     content = json.loads(response.content)
-
     assert content["count"] == 1
+
+    results = content["results"]
+    assert (
+        results[0]["metadata"]["user_capabilities"]
+        == EXPECTED_USER_CAPABILITIES
+    )
 
     scope_queryset.assert_called_once()
 
@@ -58,6 +79,9 @@ def test_portfolio_retrieve(api_request):
     assert response.status_code == 200
     content = json.loads(response.content)
     assert content["id"] == portfolio.id
+    assert (
+        content["metadata"]["user_capabilities"] == EXPECTED_USER_CAPABILITIES
+    )
 
 
 @pytest.mark.django_db

--- a/pinakes/main/catalog/tests/functional/test_portfolio_item_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_portfolio_item_end_points.py
@@ -22,6 +22,21 @@ from pinakes.main.inventory.tests.factories import (
 )
 
 
+EXPECTED_USER_CAPABILITIES = {
+    "create": True,
+    "retrieve": True,
+    "update": True,
+    "partial_update": True,
+    "destroy": True,
+    "copy": True,
+    "icon": True,
+    "next_name": True,
+    "tag": True,
+    "tags": True,
+    "untag": True,
+}
+
+
 @pytest.mark.django_db
 def test_portfolio_item_list(api_request, mocker):
     """Get list of Portfolio Items"""
@@ -36,6 +51,12 @@ def test_portfolio_item_list(api_request, mocker):
     content = json.loads(response.content)
 
     assert content["count"] == 1
+
+    results = content["results"]
+    assert (
+        results[0]["metadata"]["user_capabilities"]
+        == EXPECTED_USER_CAPABILITIES
+    )
 
     scope_queryset.assert_called_once()
 
@@ -55,8 +76,11 @@ def test_portfolio_item_retrieve(api_request, mocker):
     assert response.status_code == 200
     content = json.loads(response.content)
     assert content["id"] == portfolio_item.id
+    assert (
+        content["metadata"]["user_capabilities"] == EXPECTED_USER_CAPABILITIES
+    )
 
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -73,7 +97,7 @@ def test_portfolio_item_delete(api_request, mocker):
 
     assert response.status_code == 204
 
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -94,7 +118,7 @@ def test_portfolio_item_patch(api_request, mocker):
 
     assert response.status_code == 200
 
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -125,7 +149,7 @@ def test_portfolio_item_post(api_request, mocker):
     response = api_request("post", "catalog:portfolioitem-list", data=data)
     assert response.status_code == 201
 
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -175,7 +199,7 @@ def test_portfolio_item_icon_post(api_request, mocker, small_image, media_dir):
 
     portfolio_item.delete()
 
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -222,7 +246,7 @@ def test_portfolio_item_icon_patch(
     assert portfolio_item.icon is not None
     portfolio_item.delete()
 
-    assert check_object_permission.call_count == 2
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -262,7 +286,7 @@ def test_portfolio_item_icon_delete(
     portfolio_item.refresh_from_db()
     assert portfolio_item.icon is None
 
-    assert check_object_permission.call_count == 2
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db
@@ -288,7 +312,7 @@ def test_portfolio_item_copy(api_request, mocker):
         PortfolioItem.objects.last().name == f"Copy of {portfolio_item.name}"
     )
 
-    check_object_permission.assert_called_once()
+    check_object_permission.assert_called()
 
 
 @pytest.mark.django_db

--- a/pinakes/main/catalog/views.py
+++ b/pinakes/main/catalog/views.py
@@ -25,7 +25,7 @@ from pinakes.common.auth.keycloak_django.utils import (
     parse_scope,
 )
 from pinakes.common.auth.keycloak_django.views import (
-    PermissionQuerySetMixin,
+    KeycloakPermissionMixin,
 )
 from pinakes.common.serializers import TaskSerializer
 from pinakes.common.tag_mixin import TagMixin
@@ -146,7 +146,7 @@ class PortfolioViewSet(
     ImageMixin,
     TagMixin,
     NestedViewSetMixin,
-    PermissionQuerySetMixin,
+    KeycloakPermissionMixin,
     QuerySetMixin,
     viewsets.ModelViewSet,
 ):
@@ -154,7 +154,8 @@ class PortfolioViewSet(
 
     serializer_class = PortfolioSerializer
     http_method_names = ["get", "post", "head", "patch", "delete"]
-    permission_classes = (IsAuthenticated, permissions.PortfolioPermission)
+    permission_classes = (IsAuthenticated,)
+    keycloak_permission = permissions.PortfolioPermission
     ordering = ("-id",)
     filterset_fields = ("name", "description", "created_at", "updated_at")
     search_fields = ("name", "description")
@@ -316,7 +317,7 @@ class PortfolioItemViewSet(
     ImageMixin,
     TagMixin,
     NestedViewSetMixin,
-    PermissionQuerySetMixin,
+    KeycloakPermissionMixin,
     QuerySetMixin,
     viewsets.ModelViewSet,
 ):
@@ -324,7 +325,8 @@ class PortfolioItemViewSet(
 
     serializer_class = PortfolioItemSerializer
     http_method_names = ["get", "post", "head", "patch", "delete"]
-    permission_classes = (IsAuthenticated, permissions.PortfolioItemPermission)
+    permission_classes = (IsAuthenticated,)
+    keycloak_permission = permissions.PortfolioItemPermission
     ordering = ("-id",)
     filterset_fields = (
         "name",
@@ -469,7 +471,7 @@ class PortfolioItemViewSet(
 )
 class OrderViewSet(
     NestedViewSetMixin,
-    PermissionQuerySetMixin,
+    KeycloakPermissionMixin,
     QuerySetMixin,
     viewsets.ModelViewSet,
 ):
@@ -477,7 +479,8 @@ class OrderViewSet(
 
     serializer_class = OrderSerializer
     http_method_names = ["get", "post", "patch", "head", "delete"]
-    permission_classes = (IsAuthenticated, permissions.OrderPermission)
+    permission_classes = (IsAuthenticated,)
+    keycloak_permission = permissions.OrderPermission
     ordering = ("-id",)
     filterset_fields = (
         "state",
@@ -545,7 +548,7 @@ class OrderViewSet(
 
 @extend_schema_view(
     retrieve=extend_schema(
-        tags=("orders", "order_items"),
+        tags=["orders", "order_items"],
         description="Get a specific order item based on the order item ID",
         parameters=[
             OpenApiParameter(
@@ -559,7 +562,7 @@ class OrderViewSet(
         ],
     ),
     list=extend_schema(
-        tags=("orders", "order_items"),
+        tags=["orders", "order_items"],
         description=(
             "Get a list of order items associated with the logged in user."
         ),
@@ -586,7 +589,7 @@ class OrderViewSet(
         },
     ),
     create=extend_schema(
-        tags=("orders", "order_items"),
+        tags=["orders", "order_items"],
         description="Add an order item to an order in pending state",
     ),
     destroy=extend_schema(
@@ -595,7 +598,7 @@ class OrderViewSet(
 )
 class OrderItemViewSet(
     NestedViewSetMixin,
-    PermissionQuerySetMixin,
+    KeycloakPermissionMixin,
     QuerySetMixin,
     viewsets.ModelViewSet,
 ):
@@ -603,7 +606,8 @@ class OrderItemViewSet(
 
     serializer_class = OrderItemSerializer
     http_method_names = ["get", "post", "head", "delete"]
-    permission_classes = (IsAuthenticated, permissions.OrderItemPermission)
+    permission_classes = (IsAuthenticated,)
+    keycloak_permission = permissions.OrderItemPermission
     ordering = ("-id",)
     filterset_fields = (
         "name",


### PR DESCRIPTION
Implement basic user capabilities support.

* Add UserCapabilitiesField class, a serializer field that
  returns user capabilities mapping.
* Implement `user_capabilities()` method in base permission class.
* Use `keycloak_permission` view attribute to indicate keycloak
  permission class explicitely, which is required for generating user
  capabilities mapping out of permission class.
* Update existing view sets to reflect changes in view's permission
  classes definition.

NOTE: This is the first of a series PRs that introduce user capabilities support. Caching will be introduced in subsequent PR.

https://issues.redhat.com/browse/SSP-2807