### PR TITLE
[SSP-2879] Fix DRF browser for SessionLogoutView

### DIFF
--- a/pinakes/main/auth/tests/functional/test_session_logout.py
+++ b/pinakes/main/auth/tests/functional/test_session_logout.py
@@ -1,5 +1,6 @@
-""" Module to test session logout end point """
+"""Module to test session logout end point."""
 import pytest
+from rest_framework import status
 
 
 @pytest.mark.django_db
@@ -7,4 +8,4 @@ def test_session_logout(api_request, mocker):
     """Logout an authenticated user from a single session"""
     mocker.patch("pinakes.main.auth.views.get_oidc_client")
     response = api_request("post", "auth:logout")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/pinakes/main/auth/views.py
+++ b/pinakes/main/auth/views.py
@@ -10,6 +10,7 @@ from rest_framework import mixins
 from drf_spectacular.utils import (
     extend_schema,
     extend_schema_view,
+    OpenApiResponse,
 )
 
 from pinakes.common.auth.keycloak_django.clients import get_oidc_client
@@ -32,19 +33,20 @@ class CurrentUserViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
         return self.request.user
 
 
-@extend_schema_view(
-    post=extend_schema(
-        description="Logout current session",
-        tags=["auth"],
-        operation_id="logout_create",
-    ),
-)
 class SessionLogoutView(APIView):
     permission_classes = (IsAuthenticated,)
 
-    def get_serializer(self):
-        return None
-
+    @extend_schema(
+        description="Logout current session",
+        tags=["auth"],
+        operation_id="logout_create",
+        request=None,
+        responses={
+            status.HTTP_204_NO_CONTENT: OpenApiResponse(
+                description="Logout successful"
+            )
+        },
+    )
     def post(self, request):
         extra_data = request.keycloak_user.extra_data
         openid_client = get_oidc_client()
@@ -52,4 +54,4 @@ class SessionLogoutView(APIView):
             extra_data["access_token"], extra_data["refresh_token"]
         )
         logout(request)
-        return Response(status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
The exception is caused by `get_serializer()` method override,
returning None.
Removing the override doesn't affect OpenAPI schema generation.

https://issues.redhat.com/browse/SSP-2879