### PR TITLE
allow override UI's build tarfile for docker-compose

### DIFF
--- a/docs/DOCKER_COMPOSE.md
+++ b/docs/DOCKER_COMPOSE.md
@@ -118,7 +118,13 @@ PINAKES_KEYCLOAK_REALM_FRONTEND_URL=https://[your-external-ip-address]:9443/auth
 ```
 
 ### Download the open api schema
+
 <http://localhost:8000/api/pinakes/v1/schema/openapi.json>
 
 ### Try with swagger UI
+
 <http://localhost:8000/api/pinakes/v1/schema/swagger-ui/>
+
+## Overriding UI
+
+You can override the UI's build providing your custom `catalog-ui.tar.gz` file inside `tools/docker/frontend/overrides` folder.

--- a/tools/docker/frontend/Dockerfile
+++ b/tools/docker/frontend/Dockerfile
@@ -1,8 +1,11 @@
 FROM registry.access.redhat.com/ubi8/nginx-120
 ARG SOURCE_NGINX_CONF=nginx.conf
+ARG PINAKES_UI_PACKAGE_URL=https://github.com/ansible/pinakes-ui/releases/download/latest/catalog-ui.tar.gz
 
 ENV CERT_PATH="${NGINX_CONFIGURATION_PATH}/certs"
 ENV CATALOG_UI_SRC="ui/catalog"
+
+
 RUN mkdir -p ${CERT_PATH}
 
 ADD ${SOURCE_NGINX_CONF} ${NGINX_CONFIGURATION_PATH}
@@ -13,7 +16,8 @@ ADD --chown=1001:1001 certs/*.key ${CERT_PATH}
 
 # ui files
 RUN mkdir -p ${CATALOG_UI_SRC}
-ADD --chown=1001:1001 https://github.com/ansible/pinakes-ui/releases/download/latest/catalog-ui.tar.gz ${CATALOG_UI_SRC}/
+COPY --chown=1001:1001 overrides/*.tar.gz ${CATALOG_UI_SRC}
+RUN if [[ ! -f ${CATALOG_UI_SRC}/catalog-ui.tar.gz ]]; then curl -L ${PINAKES_UI_PACKAGE_URL} --output ${CATALOG_UI_SRC}/catalog-ui.tar.gz; fi
 RUN cd ${CATALOG_UI_SRC} && tar -xf catalog-ui.tar.gz && rm -rf catalog-ui.tar.gz
 
 


### PR DESCRIPTION
- Allow overrides the UI's tar file at frontend image build time for docker-compose based environments
- Add documentation
- Standardize docs format. 