### PR TITLE
[SSP-2885] Add endpoint to cancel the order

### DIFF
--- a/pinakes/main/catalog/exceptions.py
+++ b/pinakes/main/catalog/exceptions.py
@@ -11,3 +11,8 @@ class BadParamsException(exceptions.APIException):
 class InvalidSurveyException(exceptions.APIException):
     status_code = status.HTTP_400_BAD_REQUEST
     default_detail = _("Invalid survey")
+
+
+class UncancelableException(exceptions.APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = _("Uncancelable Order")

--- a/pinakes/main/catalog/services/cancel_order.py
+++ b/pinakes/main/catalog/services/cancel_order.py
@@ -1,0 +1,65 @@
+""" Cancel an order request"""
+import logging
+
+from django.utils.translation import gettext_lazy as _
+
+from pinakes.main.approval.models import Action
+from pinakes.main.approval.services.create_action import (
+    CreateAction,
+)
+from pinakes.main.catalog.exceptions import (
+    UncancelableException,
+)
+from pinakes.main.catalog.models import ApprovalRequest, Order
+
+logger = logging.getLogger("catalog")
+
+
+class CancelOrder:
+    """Cancel an order request"""
+
+    UNCANCELLABLE_STATES = [
+        Order.State.COMPLETED,
+        Order.State.FAILED,
+        Order.State.ORDERED,
+    ]
+
+    def __init__(self, order):
+        self.order = order
+
+    def process(self):
+        if self.order.state in self.UNCANCELLABLE_STATES:
+            self._raise_uncancellable_error()
+
+        try:
+            approval_requests = ApprovalRequest.objects.filter(
+                order=self.order
+            )
+            for request in approval_requests:
+                CreateAction(
+                    request.approval_request_ref,
+                    {
+                        "operation": Action.Operation.CANCEL,
+                        "comments": f"Order {self.order.id} canceled",
+                    },
+                ).process()
+
+            self.order.state = Order.State.CANCELED
+            self.order.save()
+            self.order.refresh_from_db()
+
+        except Exception as error:
+            logger.error(
+                "Failed to cancel order %d, error: %s", self.order.id, error
+            )
+            self._raise_uncancellable_error()
+
+        return self
+
+    def _raise_uncancellable_error(self):
+        error_message = _(
+            "Order {} is not cancelable in its current state: {}"
+        ).format(self.order.id, self.order.state)
+        logger.error(error_message)
+
+        raise UncancelableException(error_message)

--- a/pinakes/main/catalog/tests/services/test_cancel_order.py
+++ b/pinakes/main/catalog/tests/services/test_cancel_order.py
@@ -1,0 +1,61 @@
+""" Test on CancelOrder service """
+import pytest
+
+from pinakes.main.approval.models import Action, Request
+from pinakes.main.catalog.models import Order
+from pinakes.main.catalog.exceptions import (
+    UncancelableException,
+)
+from pinakes.main.catalog.services.cancel_order import (
+    CancelOrder,
+)
+
+from pinakes.main.approval.tests.factories import (
+    RequestFactory,
+)
+from pinakes.main.catalog.tests.factories import (
+    ApprovalRequestFactory,
+    OrderFactory,
+)
+
+
+@pytest.mark.django_db
+def test_cancel_order():
+    approval_request = RequestFactory()
+    order = OrderFactory()
+    ApprovalRequestFactory(
+        order=order, approval_request_ref=str(approval_request.id)
+    )
+
+    svc = CancelOrder(order)
+    svc.process()
+
+    approval_request.refresh_from_db()
+
+    assert order.state == Order.State.CANCELED
+    assert approval_request.state == Request.State.CANCELED
+    assert Action.objects.count() == 1
+    assert Action.objects.first().operation == Action.Operation.CANCEL
+
+
+@pytest.mark.django_db
+def test_cancel_order_with_uncancelable_states():
+    approval_request = RequestFactory()
+
+    for state in [
+        Order.State.ORDERED,
+        Order.State.FAILED,
+        Order.State.COMPLETED,
+    ]:
+        order = OrderFactory(state=state)
+        ApprovalRequestFactory(
+            order=order, approval_request_ref=str(approval_request.id)
+        )
+
+        svc = CancelOrder(order)
+        with pytest.raises(UncancelableException) as excinfo:
+            svc.process()
+
+        assert str(excinfo.value) == (
+            "Order {} is not cancelable in its current state: {}"
+        ).format(order.id, order.state)

--- a/pinakes/main/catalog/views.py
+++ b/pinakes/main/catalog/views.py
@@ -65,6 +65,9 @@ from pinakes.main.catalog.serializers import (
     SharingPermissionSerializer,
 )
 
+from pinakes.main.catalog.services.cancel_order import (
+    CancelOrder,
+)
 from pinakes.main.catalog.services.collect_tag_resources import (
     CollectTagResources,
 )
@@ -473,7 +476,7 @@ class OrderViewSet(
     """API endpoint for listing and creating orders."""
 
     serializer_class = OrderSerializer
-    http_method_names = ["get", "post", "head", "delete"]
+    http_method_names = ["get", "post", "patch", "head", "delete"]
     permission_classes = (IsAuthenticated, permissions.OrderPermission)
     ordering = ("-id",)
     filterset_fields = (
@@ -524,7 +527,6 @@ class OrderViewSet(
         serializer = self.get_serializer(order)
         return Response(serializer.data)
 
-    # TODO:
     @extend_schema(
         description="Cancel the given order",
         request=None,
@@ -533,7 +535,12 @@ class OrderViewSet(
     @action(methods=["patch"], detail=True)
     def cancel(self, request, pk):
         """Cancels the specified pk order."""
-        pass
+        order = self.get_object()
+
+        svc = CancelOrder(order).process()
+        serializer = self.get_serializer(svc.order)
+
+        return Response(serializer.data, status=status.HTTP_204_NO_CONTENT)
 
 
 @extend_schema_view(


### PR DESCRIPTION
Add the endpoint `/orders/:id/cancel` to cancel the order

https://issues.redhat.com/browse/SSP-2885