### PR TITLE
[SSP-2894] Added user first name & last name to searchable fields

### DIFF
--- a/pinakes/main/catalog/views.py
+++ b/pinakes/main/catalog/views.py
@@ -157,7 +157,13 @@ class PortfolioViewSet(
     permission_classes = (IsAuthenticated, permissions.PortfolioPermission)
     ordering = ("-id",)
     filterset_fields = ("name", "description", "created_at", "updated_at")
-    search_fields = ("name", "description")
+    search_fields = (
+        "name",
+        "description",
+        "user__first_name",
+        "user__last_name",
+        "user__username",
+    )
 
     @extend_schema(
         description="Make a copy of the portfolio",


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2894

Allow for Portfolio searches to include  user's 
* first_name
* last_name
* username