### PR TITLE
Refactoring: Pass request object to permission helper functions

### DIFF
--- a/pinakes/main/approval/permissions.py
+++ b/pinakes/main/approval/permissions.py
@@ -7,8 +7,6 @@ from django.shortcuts import get_object_or_404
 from rest_framework.request import Request as HttpRequest
 from rest_framework.permissions import BasePermission
 
-from pinakes.common.auth.keycloak_django.clients import get_authz_client
-
 from pinakes.common.auth.keycloak_django.permissions import (
     KeycloakPolicy,
     BaseKeycloakPermission,
@@ -43,7 +41,7 @@ class TemplatePermission(BaseKeycloakPermission):
         return check_wildcard_permission(
             Template.keycloak_type(),
             permission,
-            get_authz_client(http_request.keycloak_user.access_token),
+            http_request,
         )
 
 
@@ -68,7 +66,7 @@ class WorkflowPermission(BaseKeycloakPermission):
         return check_wildcard_permission(
             Workflow.keycloak_type(),
             permission,
-            get_authz_client(http_request.keycloak_user.access_token),
+            http_request,
         )
 
 
@@ -90,7 +88,7 @@ class RequestPermission(BaseKeycloakPermission):
         return check_wildcard_permission(
             Request.keycloak_type(),
             permission,
-            get_authz_client(http_request.keycloak_user.access_token),
+            http_request,
         )
 
     def perform_check_object_permission(
@@ -114,7 +112,7 @@ class RequestPermission(BaseKeycloakPermission):
         resources = get_permitted_resources(
             Request.keycloak_type(),
             permission,
-            get_authz_client(http_request.keycloak_user.access_token),
+            http_request,
         )
         if persona == PERSONA_ADMIN and resources.is_wildcard:
             if "parent_id" not in view.kwargs:
@@ -152,5 +150,5 @@ def _request_has_permission(request, http_request):
         request.keycloak_type(),
         request.keycloak_name(),
         "read",
-        get_authz_client(http_request.keycloak_user.access_token),
+        http_request,
     )

--- a/pinakes/main/catalog/permissions.py
+++ b/pinakes/main/catalog/permissions.py
@@ -4,9 +4,6 @@ from django.db import models
 from django.shortcuts import get_object_or_404
 from rest_framework.request import Request
 
-from pinakes.common.auth.keycloak_django.clients import (
-    get_authz_client,
-)
 from pinakes.common.auth.keycloak_django.permissions import (
     KeycloakPolicy,
     BaseKeycloakPermission,
@@ -49,7 +46,7 @@ class PortfolioPermission(BaseKeycloakPermission):
         return check_wildcard_permission(
             Portfolio.keycloak_type(),
             permission,
-            get_authz_client(request.keycloak_user.access_token),
+            request,
         )
 
     def perform_check_object_permission(
@@ -60,7 +57,7 @@ class PortfolioPermission(BaseKeycloakPermission):
         return check_object_permission(
             obj,
             permission,
-            get_authz_client(request.keycloak_user.access_token),
+            request,
         )
 
     def perform_scope_queryset(
@@ -73,7 +70,7 @@ class PortfolioPermission(BaseKeycloakPermission):
         resources = get_permitted_resources(
             Portfolio.keycloak_type(),
             permission,
-            get_authz_client(request.keycloak_user.access_token),
+            request,
         )
         if resources.is_wildcard:
             return qs
@@ -122,7 +119,7 @@ class PortfolioItemPermission(BaseKeycloakPermission):
         return check_object_permission(
             obj,
             permission,
-            get_authz_client(request.keycloak_user.access_token),
+            request,
         )
 
     def perform_scope_queryset(
@@ -135,7 +132,7 @@ class PortfolioItemPermission(BaseKeycloakPermission):
         resources = get_permitted_resources(
             Portfolio.keycloak_type(),
             permission,
-            get_authz_client(request.keycloak_user.access_token),
+            request,
         )
         if resources.is_wildcard:
             return qs
@@ -163,7 +160,7 @@ class OrderPermission(BaseKeycloakPermission):
         if check_wildcard_permission(
             obj.keycloak_type(),
             permission,
-            get_authz_client(request.keycloak_user.access_token),
+            request,
         ):
             return True
         return obj.user == request.user
@@ -174,7 +171,7 @@ class OrderPermission(BaseKeycloakPermission):
         if check_wildcard_permission(
             Order.keycloak_type(),
             permission,
-            get_authz_client(request.keycloak_user.access_token),
+            request,
         ):
             return qs
         return qs.filter(user=request.user)
@@ -218,7 +215,7 @@ class OrderItemPermission(BaseKeycloakPermission):
         if check_wildcard_permission(
             Order.keycloak_type(),
             permission,
-            get_authz_client(request.keycloak_user.access_token),
+            request,
         ):
             return qs
         # NOTE(cutwater): OrderItem and Order models both have FK to user.
@@ -232,5 +229,5 @@ class OrderItemPermission(BaseKeycloakPermission):
         return check_wildcard_permission(
             order.keycloak_type(),
             permission,
-            get_authz_client(request.keycloak_user.access_token),
+            request,
         )


### PR DESCRIPTION
Reduce code duplication by passing request object to the permission
helper functions:
    - check_wildcard_permission
    - check_object_permission
    - get_permitted_resources