### PR TITLE
Add missing localization l10n setting

### DIFF
--- a/pinakes/settings/defaults.py
+++ b/pinakes/settings/defaults.py
@@ -180,6 +180,7 @@ LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"
 
 USE_I18N = True
+USE_L10N = True
 
 USE_TZ = True
 


### PR DESCRIPTION
To support i18n, we also need to enable l10n flag.