### PR TITLE
Add group_name to the email content

### DIFF
--- a/pinakes/data/email_template.html
+++ b/pinakes/data/email_template.html
@@ -558,7 +558,7 @@
                   <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                     <tr>
                       <td class="rh-footer__text">
-                        This email was sent by the Pinakes project
+                        This email was sent by the Pinakes project. You received this email because you are a member of group $group_name
                       </td>
                     </tr>
                   </table>

--- a/pinakes/main/approval/services/email_notification.py
+++ b/pinakes/main/approval/services/email_notification.py
@@ -96,6 +96,7 @@ class EmailNotification:
         params = {
             "approval_id": self.request.id,
             "approver_name": f"{approver.firstName} {approver.lastName}",
+            "group_name": self.request.group_name,
             "orderer_email": self.request.user.email,
             "requester_name": self.request.requester_name,
             "order_id": content["order_id"],


### PR DESCRIPTION
Add the following phrase to the email body: `You received this email because you are a member of group ...`. This is helpful to explain if why an approver receives multiple email notifications if he happens to belong to two groups.