### PR TITLE
[SSP-2675] Add progress message permission

### DIFF
--- a/pinakes/main/catalog/models.py
+++ b/pinakes/main/catalog/models.py
@@ -181,8 +181,10 @@ class PortfolioItem(KeycloakMixin, ImageableModel, UserOwnedModel):
         return self.name
 
 
-class ProgressMessage(BaseModel):
+class ProgressMessage(KeycloakMixin, BaseModel):
     """Progress Message Model"""
+
+    KEYCLOAK_TYPE = "catalog:progress_message"
 
     class Level(models.TextChoices):
         """Available levels for ProgressMessage"""

--- a/pinakes/main/catalog/permissions.py
+++ b/pinakes/main/catalog/permissions.py
@@ -11,7 +11,12 @@ from pinakes.common.auth.keycloak_django.permissions import (
     check_object_permission,
     get_permitted_resources,
 )
-from pinakes.main.catalog.models import Portfolio, PortfolioItem, Order
+from pinakes.main.catalog.models import (
+    Portfolio,
+    PortfolioItem,
+    Order,
+    ProgressMessage,
+)
 
 
 class PortfolioPermission(BaseKeycloakPermission):
@@ -228,6 +233,25 @@ class OrderItemPermission(BaseKeycloakPermission):
             return True
         return check_wildcard_permission(
             order.keycloak_type(),
+            permission,
+            request,
+        )
+
+
+class ProgressMessagePermission(BaseKeycloakPermission):
+    access_policies = {
+        "list": KeycloakPolicy("read", KeycloakPolicy.Type.WILDCARD),
+    }
+
+    def perform_check_permission(
+        self, permission: str, request: Request, view: Any
+    ) -> bool:
+        messageable_id = view.kwargs["messageable_id"]
+        obj = get_object_or_404(view.messageable_model, pk=messageable_id)
+        if obj.owner == request.user:
+            return True
+        return check_wildcard_permission(
+            ProgressMessage.keycloak_type(),
             permission,
             request,
         )

--- a/pinakes/main/catalog/tests/functional/test_progress_message_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_progress_message_end_points.py
@@ -2,6 +2,7 @@
 import json
 import pytest
 
+from pinakes.main.catalog.permissions import ProgressMessagePermission
 from pinakes.main.catalog.tests.factories import (
     OrderFactory,
 )
@@ -11,8 +12,11 @@ from pinakes.main.catalog.tests.factories import (
 
 
 @pytest.mark.django_db
-def test_order_progress_message_get(api_request):
+def test_order_progress_message_get(api_request, mocker):
     """Get List of Progress Messages of an order"""
+    perform_check_object_permission = mocker.spy(
+        ProgressMessagePermission, "perform_check_permission"
+    )
     order = OrderFactory()
     order.update_message("Info", "test order message")
     response = api_request(
@@ -28,10 +32,15 @@ def test_order_progress_message_get(api_request):
     assert entry["message"] == "test order message"
     assert entry["messageable_type"] == "Order"
 
+    perform_check_object_permission.assert_called()
+
 
 @pytest.mark.django_db
-def test_order_item_progress_message_get(api_request):
+def test_order_item_progress_message_get(api_request, mocker):
     """Get List of Progress Messages of an order"""
+    perform_check_object_permission = mocker.spy(
+        ProgressMessagePermission, "perform_check_permission"
+    )
     order_item = OrderItemFactory()
     order_item.update_message("Info", "test order item message")
 
@@ -47,3 +56,5 @@ def test_order_item_progress_message_get(api_request):
     entry = content["results"][0]
     assert entry["message"] == "test order item message"
     assert entry["messageable_type"] == "OrderItem"
+
+    perform_check_object_permission.assert_called()

--- a/pinakes/main/catalog/tests/unit/test_progress_message_permissions.py
+++ b/pinakes/main/catalog/tests/unit/test_progress_message_permissions.py
@@ -1,0 +1,101 @@
+from unittest import mock
+
+import pytest
+
+from pinakes.common.auth.keycloak_django.permissions import KeycloakPolicy
+from pinakes.main.catalog.models import Order
+from pinakes.main.catalog.permissions import ProgressMessagePermission
+from pinakes.main.catalog.tests.factories import OrderFactory
+from pinakes.main.tests.factories import UserFactory
+
+
+@pytest.fixture(autouse=True)
+def _mock_autz_client(mocker):
+    mocker.patch(
+        "pinakes.common.auth.keycloak_django.clients.get_authz_client"
+    )
+
+
+def _test_get_permissions(type_, action, expected, view_kwargs=None):
+    view = mock.Mock(action=action, kwargs=view_kwargs or {})
+    permission = ProgressMessagePermission().get_required_permission(
+        type_, mock.Mock(), view
+    )
+    assert permission == expected
+
+
+@pytest.mark.parametrize(("action", "expected"), [("list", "read")])
+def test_wildcard_permissions(action, expected):
+    _test_get_permissions(KeycloakPolicy.Type.WILDCARD, action, expected)
+
+
+@pytest.mark.django_db
+@mock.patch(
+    "pinakes.main.catalog.permissions.check_wildcard_permission",
+    return_value=False,
+)
+def test_wildcard_is_owner(check_wildcard_permission):
+    order = OrderFactory()
+
+    request = mock.Mock()
+    request.user = order.owner
+    view = mock.Mock(
+        action="list",
+        messageable_model=Order,
+        kwargs={"messageable_id": order.id},
+    )
+
+    permission = ProgressMessagePermission()
+    assert permission.has_permission(request, view) is True
+
+    check_wildcard_permission.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch(
+    "pinakes.main.catalog.permissions.check_wildcard_permission",
+    return_value=True,
+)
+def test_wildcard_has_wildcard(check_wildcard_permission):
+    user = UserFactory()
+    order = OrderFactory()
+
+    request = mock.Mock()
+    request.user = user
+    view = mock.Mock(
+        action="list",
+        messageable_model=Order,
+        kwargs={"messageable_id": order.id},
+    )
+
+    permission = ProgressMessagePermission()
+    assert permission.has_permission(request, view) is True
+
+    check_wildcard_permission.assert_called_once_with(
+        "catalog:progress_message", "read", request
+    )
+
+
+@pytest.mark.django_db
+@mock.patch(
+    "pinakes.main.catalog.permissions.check_wildcard_permission",
+    return_value=False,
+)
+def test_wildcard_no_access(check_wildcard_permission):
+    user = UserFactory()
+    order = OrderFactory()
+
+    request = mock.Mock()
+    request.user = user
+    view = mock.Mock(
+        action="list",
+        messageable_model=Order,
+        kwargs={"messageable_id": order.id},
+    )
+
+    permission = ProgressMessagePermission()
+    assert permission.has_permission(request, view) is False
+
+    check_wildcard_permission.assert_called_once_with(
+        "catalog:progress_message", "read", request
+    )

--- a/pinakes/main/catalog/urls.py
+++ b/pinakes/main/catalog/urls.py
@@ -9,7 +9,8 @@ from pinakes.main.catalog.views import (
     OrderItemViewSet,
     PortfolioViewSet,
     PortfolioItemViewSet,
-    ProgressMessageViewSet,
+    OrderProgressMessageViewSet,
+    OrderItemProgressMessageViewSet,
     TenantViewSet,
 )
 
@@ -68,7 +69,7 @@ orders.register(
 )
 orders.register(
     r"progress_messages",
-    ProgressMessageViewSet,
+    OrderProgressMessageViewSet,
     basename="order-progressmessage",
     parents_query_lookups=["messageable"],
 )
@@ -83,7 +84,7 @@ order_items = router.register(
 )
 order_items.register(
     r"progress_messages",
-    ProgressMessageViewSet,
+    OrderItemProgressMessageViewSet,
     basename="orderitem-progressmessage",
     parents_query_lookups=["messageable"],
 )


### PR DESCRIPTION
Implement a permission class for `ProgressMessage` viewset.

Issue: https://issues.redhat.com/browse/SSP-2765