### PR TITLE
Misc: Make ProgressMessage model fields non nullable

### DIFF
--- a/pinakes/main/catalog/models.py
+++ b/pinakes/main/catalog/models.py
@@ -210,11 +210,12 @@ class ProgressMessage(KeycloakMixin, BaseModel):
     )
     messageable_type = models.CharField(
         max_length=64,
-        null=True,
+        editable=False,
         help_text="Identify order or order item that this message belongs to",
     )
     messageable_id = models.IntegerField(
-        editable=False, null=True, help_text="ID of the order or order item"
+        editable=False,
+        help_text="ID of the order or order item",
     )
 
     class Meta:

--- a/pinakes/main/migrations/0046_progressmessage_nullable_fields.py
+++ b/pinakes/main/migrations/0046_progressmessage_nullable_fields.py
@@ -1,0 +1,55 @@
+import logging
+
+from django.db import migrations, models
+from django.db.models import Q
+
+
+logger = logging.getLogger("pinakes")
+
+
+def upgrade_delete_invalid_progressmessages(apps, schema_editor):
+    ProgressMessage = apps.get_model("main", "ProgressMessage")
+    db_alias = schema_editor.connection.alias
+    deleted_count, _ = (
+        ProgressMessage.objects.using(db_alias)
+        .filter(
+            Q(messageable_id__isnull=True) | Q(messageable_type__isnull=True)
+        )
+        .delete()
+    )
+    if deleted_count:
+        logger.warning(
+            f"Deleted {deleted_count} invalid ProgressMessage records."
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("main", "0045_source_last_refresh_stats"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=upgrade_delete_invalid_progressmessages,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="progressmessage",
+            name="messageable_id",
+            field=models.IntegerField(
+                editable=False, help_text="ID of the order or order item"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="progressmessage",
+            name="messageable_type",
+            field=models.CharField(
+                editable=False,
+                help_text=(
+                    "Identify order or order item that this message belongs to"
+                ),
+                max_length=64,
+            ),
+        ),
+    ]


### PR DESCRIPTION
The `messageable_type` and `messageable_id` are not expected to
contain `NULL` value. This patch makes those fields non-nullable.