### PR TITLE
Fix progress message owner permission check

### DIFF
--- a/pinakes/main/catalog/permissions.py
+++ b/pinakes/main/catalog/permissions.py
@@ -248,7 +248,7 @@ class ProgressMessagePermission(BaseKeycloakPermission):
     ) -> bool:
         messageable_id = view.kwargs["messageable_id"]
         obj = get_object_or_404(view.messageable_model, pk=messageable_id)
-        if obj.owner == request.user:
+        if obj.user == request.user:
             return True
         return check_wildcard_permission(
             ProgressMessage.keycloak_type(),

--- a/pinakes/main/catalog/tests/unit/test_progress_message_permissions.py
+++ b/pinakes/main/catalog/tests/unit/test_progress_message_permissions.py
@@ -38,7 +38,7 @@ def test_wildcard_is_owner(check_wildcard_permission):
     order = OrderFactory()
 
     request = mock.Mock()
-    request.user = order.owner
+    request.user = order.user
     view = mock.Mock(
         action="list",
         messageable_model=Order,


### PR DESCRIPTION
The `owner` property returns string representation of a user.
The `user` attribute must be used instead.