### PR TITLE
Removed the approval-user role

### DIFF
--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -7,13 +7,12 @@ For ease of development as part of the keycloak setup we create the following gr
  - **catalog-admin**
  - **catalog-user**
  - **approval-admin**
- - **approval-user**
  - **approval-approver**
 
 The following groups are created
 
  - **Information Technology - Sample** (roles assigned catalog-admin, approval-admin)
- - **Marketing - Sample** (roles assigned catalog-user, approval-user)
+ - **Marketing - Sample** (roles assigned catalog-user)
  - **Finance - Sample** (roles assigned approval-approver)
 
 The following users are also created

--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -8,7 +8,6 @@ Automation Services Catalog uses Keycloak for Authentication and Authorization. 
  - catalog-user
  - approval-admin
  - approval-approver
- - approval-user
 
 ## catalog-admin
 Allows the logged in user to function as an Administrator and create, update, read, delete all objects in the Automation Services Catalog. A catalog-admin role doesn't allow you to Approve any pending requests. You would need the approval-admin role attached to the user to do that.
@@ -22,9 +21,6 @@ Allows the logged in user to create, read, update, delete Approval Processes. Ap
 ## approval-approver
 Allows the logged in user to Approve/Deny any pending requests. A approver cannot create Approval Processes.
 
-## approval-user
-Is a regular user who can track the process of his Approval Requests.
-
 
 ## Applying RBAC
  - Create Groups in Keycloak and assign them one or more of the above mentioned roles.
@@ -36,7 +32,7 @@ Is a regular user who can track the process of his Approval Requests.
 ## A approver group with only the approval-approver role
 ![Alt_ApproverGroup](./approver-group.png?raw=true)
 
-## A standard user group with the catalog-user and approval-user role
+## A standard user group with the catalog-user role
 ![Alt_UserGroup](./regular-user-group.png?raw=true)
 
 ## Adding users to groups

--- a/tools/keycloak_setup/collection/roles/setup/vars/catalog_rbac.yml
+++ b/tools/keycloak_setup/collection/roles/setup/vars/catalog_rbac.yml
@@ -115,22 +115,6 @@ roles:
             scope_name: approval:access
             type: scope
         type: role
-  approval-user:
-    description: 'The Approval User can look at the status of the Approval Requests'
-    name: 'Approval User'
-    policies:
-      - decisionStrategy: UNANIMOUS
-        description: 'Approval User Policy'
-        logic: POSITIVE
-        name: approval-user-policy
-        permissions:
-          - decisionStrategy: UNANIMOUS
-            description: 'User access to Approval Automation Services Catalog'
-            logic: POSITIVE
-            name: approval-user-access-permission
-            scope_name: approval:access
-            type: scope
-        type: role
   catalog-admin:
     description: 'The Catalog Administrator has access to all objects in catalog'
     name: 'Catalog Administrator'

--- a/tools/keycloak_setup/dev.yml
+++ b/tools/keycloak_setup/dev.yml
@@ -11,7 +11,6 @@
       - name: Marketing - Sample
         clientRoles:
           - catalog-user
-          - approval-user
       - name: Finance - Sample
         clientRoles:
           - approval-approver


### PR DESCRIPTION
The approval-user is some thing that we brought over from the
cloud version when the services were separate and we needed a
default role for Approval service. Now that we are on premise
we don't have separate services so we dont need the approval-user
role