### PR TITLE
[SSP-2855] Fix permission check on PortfolioItem copy

### DIFF
--- a/pinakes/main/catalog/permissions.py
+++ b/pinakes/main/catalog/permissions.py
@@ -98,7 +98,7 @@ class PortfolioItemPermission(BaseKeycloakPermission):
         "untag": KeycloakPolicy("update", KeycloakPolicy.Type.OBJECT),
         # Custom actions
         "icon": KeycloakPolicy("update", KeycloakPolicy.Type.OBJECT),
-        "copy": KeycloakPolicy("update", KeycloakPolicy.Type.OBJECT),
+        "copy": KeycloakPolicy("read", KeycloakPolicy.Type.OBJECT),
         "next_name": KeycloakPolicy("read", KeycloakPolicy.Type.OBJECT),
     }
 

--- a/pinakes/main/catalog/services/copy_portfolio.py
+++ b/pinakes/main/catalog/services/copy_portfolio.py
@@ -58,9 +58,7 @@ class CopyPortfolio:
         )
         for item in portfolio_items:
             try:
-                CopyPortfolioItem(
-                    item, {"portfolio_id": self.new_portfolio.id}
-                ).process()
+                CopyPortfolioItem(item, self.new_portfolio).process()
             except Exception as error:
                 logger.error(
                     "Failed to copy portfolio item %d: %s", item.id, str(error)

--- a/pinakes/main/catalog/services/copy_portfolio_item.py
+++ b/pinakes/main/catalog/services/copy_portfolio_item.py
@@ -1,20 +1,14 @@
 """Copy portfolio item service"""
 import copy
 import logging
+from typing import Optional
+
 from django.utils.translation import gettext_lazy as _
 from django.db import transaction
 
-from pinakes.main.catalog.models import (
-    ServicePlan,
-    Portfolio,
-    PortfolioItem,
-)
-from pinakes.main.catalog.services import (
-    name,
-)
-from pinakes.main.catalog.services.copy_image import (
-    CopyImage,
-)
+from pinakes.main.catalog.models import ServicePlan, PortfolioItem, Portfolio
+from pinakes.main.catalog.services import name
+from pinakes.main.catalog.services.copy_image import CopyImage
 from pinakes.main.inventory.services.get_service_offering import (
     GetServiceOffering,
 )
@@ -25,15 +19,19 @@ logger = logging.getLogger("catalog")
 class CopyPortfolioItem:
     """Copy portfolio item service"""
 
-    def __init__(self, portfolio_item, options):
+    def __init__(
+        self,
+        portfolio_item: PortfolioItem,
+        portfolio: Optional[Portfolio] = None,
+        portfolio_item_name: Optional[str] = None,
+    ):
         self.portfolio_item = portfolio_item
-        self.name = options.get("portfolio_item_name", portfolio_item.name)
-
-        portfolio_id = options.get("portfolio_id", None)
-        if portfolio_id:
-            self.portfolio = Portfolio.objects.get(id=portfolio_id)
-        else:
-            self.portfolio = self.portfolio_item.portfolio
+        if portfolio is None:
+            portfolio = self.portfolio_item.portfolio
+        self.portfolio = portfolio
+        if portfolio_item_name is None:
+            portfolio_item_name = self.portfolio_item.name
+        self.name = portfolio_item_name
 
         self.new_portfolio_item = None
 

--- a/pinakes/main/catalog/tests/functional/test_portfolio_item_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_portfolio_item_end_points.py
@@ -3,6 +3,8 @@ import os
 import glob
 
 import json
+from unittest import mock
+
 import pytest
 
 from pinakes.main.catalog.models import PortfolioItem
@@ -292,6 +294,9 @@ def test_portfolio_item_icon_delete(
 @pytest.mark.django_db
 def test_portfolio_item_copy(api_request, mocker):
     """Copy a PortfolioItem by id"""
+    mocker.patch.object(
+        PortfolioItemPermission, "get_user_capabilities", return_value={}
+    )
     check_object_permission = mocker.spy(
         PortfolioItemPermission, "perform_check_object_permission"
     )
@@ -312,7 +317,21 @@ def test_portfolio_item_copy(api_request, mocker):
         PortfolioItem.objects.last().name == f"Copy of {portfolio_item.name}"
     )
 
-    check_object_permission.assert_called()
+    read_call = mock.call(
+        mock.ANY,
+        "read",
+        mock.ANY,
+        mock.ANY,
+        portfolio_item,
+    )
+    update_call = mock.call(
+        mock.ANY,
+        "update",
+        mock.ANY,
+        mock.ANY,
+        portfolio_item.portfolio,
+    )
+    check_object_permission.assert_has_calls([read_call, update_call])
 
 
 @pytest.mark.django_db

--- a/pinakes/main/catalog/tests/services/test_copy_portfolio_item.py
+++ b/pinakes/main/catalog/tests/services/test_copy_portfolio_item.py
@@ -1,18 +1,11 @@
 """Test copy portfolio item service"""
 import pytest
 
-from pinakes.main.catalog.models import (
-    ServicePlan,
-    PortfolioItem,
-)
-from pinakes.main.catalog.services.copy_portfolio_item import (
-    CopyPortfolioItem,
-)
+from pinakes.main.catalog.models import ServicePlan, PortfolioItem
+from pinakes.main.catalog.services.copy_portfolio_item import CopyPortfolioItem
 from pinakes.main.catalog.tests.factories import (
     PortfolioFactory,
     PortfolioItemFactory,
-)
-from pinakes.main.catalog.tests.factories import (
     ServicePlanFactory,
 )
 from pinakes.main.inventory.tests.factories import (
@@ -51,12 +44,10 @@ SCHEMA = {
 def test_is_orderable_with_null_service_offering():
     portfolio = PortfolioFactory()
     portfolio_item = PortfolioItemFactory(portfolio=portfolio)
-    options = {
-        "portfolio_item_name": "my test",
-        "portfolio_id": portfolio.id,
-    }
 
-    svc = CopyPortfolioItem(portfolio_item, options)
+    svc = CopyPortfolioItem(
+        portfolio_item, portfolio, portfolio_item_name="my test"
+    )
     orderable = svc._is_orderable()
 
     assert orderable is False
@@ -70,11 +61,7 @@ def test_is_orderable_with_empty_service_plans():
         service_offering_ref=str(service_offering.id),
         portfolio=portfolio,
     )
-    options = {
-        "portfolio_item_name": "my test",
-    }
-
-    svc = CopyPortfolioItem(portfolio_item, options)
+    svc = CopyPortfolioItem(portfolio_item, portfolio_item_name="my test")
     orderable = svc._is_orderable()
 
     assert orderable is True
@@ -93,11 +80,7 @@ def test_is_orderable_with_service_plans():
     )
     ServicePlanFactory(base_schema={}, portfolio_item=portfolio_item)
 
-    options = {
-        "portfolio_item_name": "my test",
-    }
-
-    svc = CopyPortfolioItem(portfolio_item, options)
+    svc = CopyPortfolioItem(portfolio_item, portfolio_item_name="my test")
     orderable = svc._is_orderable()
 
     assert orderable is True
@@ -117,14 +100,12 @@ def test_copy_portfolio_items_to_the_same_portfolio():
     )
     ServicePlanFactory(portfolio_item=portfolio_item)
 
-    options = {
-        "portfolio_item_name": portfolio_item.name,
-    }
-
     assert PortfolioItem.objects.count() == 1
     assert ServicePlan.objects.count() == 1
 
-    svc = CopyPortfolioItem(portfolio_item, options)
+    svc = CopyPortfolioItem(
+        portfolio_item, portfolio_item_name=portfolio_item.name
+    )
     svc.process()
 
     assert PortfolioItem.objects.count() == 2
@@ -151,14 +132,10 @@ def test_copy_portfolio_items_to_different_portfolios():
         service_offering_ref=str(service_offering.id),
     )
 
-    options = {
-        "portfolio_id": portfolio_2.id,
-    }
-
     assert PortfolioItem.objects.count() == 1
     assert PortfolioItem.objects.filter(portfolio=portfolio_2).count() == 0
 
-    svc = CopyPortfolioItem(portfolio_item, options)
+    svc = CopyPortfolioItem(portfolio_item, portfolio_2)
     svc.process()
 
     assert PortfolioItem.objects.count() == 2
@@ -175,7 +152,7 @@ def test_copy_portfolio_items_to_raise_exception():
     portfolio_item = PortfolioItemFactory(portfolio=portfolio)
 
     with pytest.raises(RuntimeError) as excinfo:
-        svc = CopyPortfolioItem(portfolio_item, {})
+        svc = CopyPortfolioItem(portfolio_item)
         svc.process()
 
     assert (

--- a/pinakes/main/catalog/views.py
+++ b/pinakes/main/catalog/views.py
@@ -384,17 +384,24 @@ class PortfolioItemViewSet(
     @action(methods=["post"], detail=True)
     def copy(self, request, pk):
         """Copy the specified pk portfolio item."""
-        portfolio_item = self.get_object()
-        options = {
-            "portfolio_item_id": portfolio_item.id,
-            "portfolio_id": request.data.get(
-                "portfolio_id", portfolio_item.portfolio.id
-            ),
-            "portfolio_item_name": request.data.get(
-                "portfolio_item_name", portfolio_item.name
-            ),
-        }
-        svc = CopyPortfolioItem(portfolio_item, options).process()
+        portfolio_item_src = self.get_object()
+
+        # TODO: Move to serializer
+        portfolio_id_dest = request.data.get("portfolio_id", None)
+        if portfolio_id_dest:
+            portfolio_dest = get_object_or_404(Portfolio, id=portfolio_id_dest)
+        else:
+            portfolio_dest = portfolio_item_src.portfolio
+        self.get_keycloak_permission().perform_check_object_permission(
+            "update", request, self, portfolio_dest
+        )
+        portfolio_item_name = request.data.get(
+            "portfolio_item_name", portfolio_item_src.name
+        )
+
+        svc = CopyPortfolioItem(
+            portfolio_item_src, portfolio_dest, portfolio_item_name
+        ).process()
         serializer = self.get_serializer(svc.new_portfolio_item)
 
         return Response(serializer.data)


### PR DESCRIPTION
Copy of a portfolio now checks `read` permission on source portfolio
item and `update` permission on target portfolio.

Issue: https://issues.redhat.com/browse/SSP-2855