### PR TITLE
Fixed typo in doc

### DIFF
--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -68,7 +68,7 @@ python3 manage.py makemessages -l zh --ignore "extract-strings-env/*" --ignore "
 ```
 
 If you want to generate messages for all the supported languages in the project use
-'``
+```
 python3 manage.py makemessages --all --ignore "extract-strings-env/*" --ignore "venv/*"
 ```
 


### PR DESCRIPTION
The markdown was missing  the backticks