### PR TITLE
[SSP-292] Use a customized get_object_or_404 to handle non integer id

### DIFF
--- a/pinakes/common/exception_handler.py
+++ b/pinakes/common/exception_handler.py
@@ -1,4 +1,6 @@
 """default exception handler for all uncaught exceptions"""
+from django.http import Http404
+from django.shortcuts import get_object_or_404
 from rest_framework.views import exception_handler, set_rollback
 from rest_framework.response import Response
 from rest_framework import status
@@ -19,3 +21,10 @@ def custom_exception_handler(exc, context):
         response = Response(data, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     return response
+
+
+def get_object_by_id_or_404(model, pk):
+    try:
+        return get_object_or_404(model, pk=pk)
+    except ValueError as e:
+        raise Http404(str(e))

--- a/pinakes/common/tag_mixin.py
+++ b/pinakes/common/tag_mixin.py
@@ -1,11 +1,10 @@
-from django.shortcuts import get_object_or_404
-
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.decorators import action
 from drf_spectacular.utils import extend_schema
 
 from .serializers import TagSerializer
+from .exception_handler import get_object_by_id_or_404
 
 
 class TagMixin:
@@ -22,7 +21,7 @@ class TagMixin:
         List all tags of a given instance
         """
         model = self.get_serializer().Meta.model
-        instance = get_object_or_404(model, pk=pk)
+        instance = get_object_by_id_or_404(model, pk)
         tags = instance.tags.all().order_by("name")
 
         page = self.paginate_queryset(tags)
@@ -42,7 +41,7 @@ class TagMixin:
             content body:    {"name": "tag"}
         """
         model = self.get_serializer().Meta.model
-        instance = get_object_or_404(model, pk=pk)
+        instance = get_object_by_id_or_404(model, pk)
 
         tag_serializer = TagSerializer(data=request.data)
         if tag_serializer.is_valid():
@@ -66,7 +65,7 @@ class TagMixin:
             content body:    {"name": "tag"}
         """
         model = self.get_serializer().Meta.model
-        instance = get_object_or_404(model, pk=pk)
+        instance = get_object_by_id_or_404(model, pk)
 
         tag_serializer = TagSerializer(data=request.data)
         if tag_serializer.is_valid():

--- a/pinakes/main/approval/permissions.py
+++ b/pinakes/main/approval/permissions.py
@@ -3,10 +3,10 @@
 from typing import Any
 
 from django.db import models
-from django.shortcuts import get_object_or_404
 from rest_framework.request import Request as HttpRequest
 from rest_framework.permissions import BasePermission
 
+from pinakes.common.exception_handler import get_object_by_id_or_404
 from pinakes.common.auth.keycloak_django.permissions import (
     KeycloakPolicy,
     BaseKeycloakPermission,
@@ -130,7 +130,7 @@ class ActionPermission(BasePermission):
         if "request_id" not in view.kwargs:
             return True
 
-        request = get_object_or_404(Request, pk=view.kwargs["request_id"])
+        request = get_object_by_id_or_404(Request, view.kwargs["request_id"])
         return _request_has_permission(request, http_request)
 
     def has_object_permission(

--- a/pinakes/main/approval/views.py
+++ b/pinakes/main/approval/views.py
@@ -12,7 +12,6 @@ from rest_framework.filters import (
 )
 from rest_framework.permissions import IsAuthenticated
 from rest_framework_extensions.mixins import NestedViewSetMixin
-from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import (
@@ -22,6 +21,7 @@ from drf_spectacular.utils import (
     OpenApiTypes,
 )
 
+from pinakes.common.exception_handler import get_object_by_id_or_404
 from pinakes.main.models import Tenant
 from pinakes.main.approval.models import (
     NotificationType,
@@ -295,7 +295,7 @@ class WorkflowViewSet(
         available to admin only.
         """
 
-        workflow = get_object_or_404(Workflow, pk=pk)
+        workflow = get_object_by_id_or_404(Workflow, pk)
         validations.validate_and_update_approver_groups(workflow)
 
         LinkWorkflow(workflow, request.data).process(
@@ -314,7 +314,7 @@ class WorkflowViewSet(
         and a workflow by its id, available to admin only
         """
 
-        workflow = get_object_or_404(Workflow, pk=pk)
+        workflow = get_object_by_id_or_404(Workflow, pk)
 
         LinkWorkflow(workflow, request.data).process(
             LinkWorkflow.Operation.REMOVE
@@ -428,7 +428,7 @@ class RequestViewSet(
     def content(self, request, pk):
         """Retrieve the content of a request"""
 
-        request = get_object_or_404(Request, pk=pk)
+        request = get_object_by_id_or_404(Request, pk)
         return Response(request.request_context.content)
 
 

--- a/pinakes/main/catalog/permissions.py
+++ b/pinakes/main/catalog/permissions.py
@@ -1,9 +1,9 @@
 from typing import Any
 
 from django.db import models
-from django.shortcuts import get_object_or_404
 from rest_framework.request import Request
 
+from pinakes.common.exception_handler import get_object_by_id_or_404
 from pinakes.common.auth.keycloak_django.permissions import (
     KeycloakPolicy,
     BaseKeycloakPermission,
@@ -200,7 +200,7 @@ class OrderItemPermission(BaseKeycloakPermission):
         order_id = view.kwargs.get("order_id")
         if order_id is None:
             return False
-        order = get_object_or_404(Order, pk=order_id)
+        order = get_object_by_id_or_404(Order, pk=order_id)
         return self._check_order_permission(permission, request, order)
 
     def perform_check_object_permission(
@@ -249,7 +249,9 @@ class ProgressMessagePermission(BaseKeycloakPermission):
         self, permission: str, request: Request, view: Any
     ) -> bool:
         messageable_id = view.kwargs["messageable_id"]
-        obj = get_object_or_404(view.messageable_model, pk=messageable_id)
+        obj = get_object_by_id_or_404(
+            view.messageable_model, pk=messageable_id
+        )
         if obj.user == request.user:
             return True
         return check_wildcard_permission(
@@ -285,11 +287,13 @@ class ServicePlanPermission(BaseKeycloakPermission):
     ) -> bool:
         portfolio_item_id = view.kwargs.get("portfolio_item_id")
         if portfolio_item_id is not None:
-            portfolio_item = get_object_or_404(
-                PortfolioItem, pk=portfolio_item_id
+            portfolio_item = get_object_by_id_or_404(
+                PortfolioItem, portfolio_item_id
             )
         else:
-            service_plan = get_object_or_404(ServicePlan, pk=view.kwargs["pk"])
+            service_plan = get_object_by_id_or_404(
+                ServicePlan, view.kwargs["pk"]
+            )
             portfolio_item = service_plan.portfolio_item
 
         if PortfolioItemPermission().perform_check_object_permission(

--- a/pinakes/main/catalog/tests/functional/test_order_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_order_end_points.py
@@ -304,3 +304,12 @@ def test_order_order_item_post(api_request, mocker):
     assert content["name"] == portfolio_item.name
     assert content["order"] == str(order.id)
     perform_check_permission.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_order_order_item_post_string_id(api_request):
+    """Create a new order item with a string order id"""
+    response = api_request(
+        "post", "catalog:order-orderitem-list", "string-id", {}
+    )
+    assert response.status_code == 404

--- a/pinakes/main/catalog/views.py
+++ b/pinakes/main/catalog/views.py
@@ -4,7 +4,6 @@ import logging
 
 import django_rq
 from django.utils.translation import gettext_lazy as _
-from django.shortcuts import get_object_or_404
 
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -20,6 +19,7 @@ from drf_spectacular.utils import (
     OpenApiResponse,
 )
 
+from pinakes.common.exception_handler import get_object_by_id_or_404
 from pinakes.common.auth import keycloak_django
 from pinakes.common.auth.keycloak_django.utils import (
     parse_scope,
@@ -361,7 +361,7 @@ class PortfolioItemViewSet(
             )
 
         portfolio_id = request.data.get("portfolio")
-        portfolio = get_object_or_404(Portfolio, pk=portfolio_id)
+        portfolio = get_object_by_id_or_404(Portfolio, portfolio_id)
         self.check_object_permissions(request, portfolio)
 
         output_serializer = PortfolioItemSerializer(
@@ -389,7 +389,9 @@ class PortfolioItemViewSet(
         # TODO: Move to serializer
         portfolio_id_dest = request.data.get("portfolio_id", None)
         if portfolio_id_dest:
-            portfolio_dest = get_object_or_404(Portfolio, id=portfolio_id_dest)
+            portfolio_dest = get_object_by_id_or_404(
+                Portfolio, portfolio_id_dest
+            )
         else:
             portfolio_dest = portfolio_item_src.portfolio
         self.get_keycloak_permission().perform_check_object_permission(
@@ -429,7 +431,7 @@ class PortfolioItemViewSet(
     @action(methods=["get"], detail=True)
     def next_name(self, request, pk):
         """Retrieve next available portfolio item name"""
-        portfolio_item = get_object_or_404(PortfolioItem, pk=pk)
+        portfolio_item = get_object_by_id_or_404(PortfolioItem, pk)
         destination_portfolio_id = request.GET.get(
             "destination_portfolio_id", None
         )
@@ -779,7 +781,7 @@ class ServicePlanViewSet(
         responses={200: ServicePlanSerializer},
     )
     def partial_update(self, request, pk):
-        service_plan = get_object_or_404(ServicePlan, pk=pk)
+        service_plan = get_object_by_id_or_404(ServicePlan, pk)
 
         serializer = ModifiedServicePlanInSerializer(data=request.data)
         if not serializer.is_valid():
@@ -807,7 +809,7 @@ class ServicePlanViewSet(
     @action(methods=["post"], detail=True)
     def reset(self, request, pk):
         """Reset the specified service plan."""
-        service_plan = get_object_or_404(ServicePlan, pk=pk)
+        service_plan = get_object_by_id_or_404(ServicePlan, pk)
 
         service_plan.modified_schema = None
         service_plan.base_schema = None

--- a/pinakes/main/inventory/views.py
+++ b/pinakes/main/inventory/views.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
@@ -12,6 +11,7 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 import rq.job as rq_job
 import django_rq
 
+from pinakes.common.exception_handler import get_object_by_id_or_404
 from pinakes.common.tag_mixin import TagMixin
 from pinakes.common.queryset_mixin import QuerySetMixin
 from pinakes.common.serializers import TaskSerializer
@@ -68,7 +68,7 @@ class SourceViewSet(NestedViewSetMixin, QuerySetMixin, ModelViewSet):
     )
     @action(methods=["patch"], detail=True)
     def refresh(self, request, pk):
-        source = get_object_or_404(Source, pk=pk)
+        source = get_object_by_id_or_404(Source, pk)
 
         if source.last_refresh_task_ref:
             try:


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2928

Default get_object_or_404 method does not raise 404 if the id is a string. This attempt is to catch the DB error and raise 404 so the user will not see a 500 error.