### PR TITLE
Override users/groups and add QA seed file

### DIFF
--- a/docs/DOCKER_COMPOSE.md
+++ b/docs/DOCKER_COMPOSE.md
@@ -128,3 +128,12 @@ PINAKES_KEYCLOAK_REALM_FRONTEND_URL=https://[your-external-ip-address]:9443/auth
 ## Overriding UI
 
 You can override the UI's build providing your custom `catalog-ui.tar.gz` file inside `tools/docker/frontend/overrides` folder.
+
+## Overriding credentials
+
+You can override the set of users and groups defined by default in `tools/keycloak_setup/dev.yml` adding your custom file defining the environement variable `KEYCLOAK_SEED_FILE`. Notice that the path must to be a relative path to the root project. For example:
+
+```
+# .env content
+KEYCLOAK_SEED_FILE=tools/keycloak_setup/custom-users.yml
+```

--- a/tools/docker/docker-compose.stage.yml
+++ b/tools/docker/docker-compose.stage.yml
@@ -27,6 +27,7 @@ x-environment:
   - PINAKES_POSTGRES_USER=admin
   - PINAKES_POSTGRES_PASSWORD=admin
   - PINAKES_POSTGRES_SSL_MODE=disable
+  - KEYCLOAK_SEED_FILE=tools/keycloak_setup/qa.yml
 
 services:
   frontend:

--- a/tools/docker/scripts/keycloak-setup.sh
+++ b/tools/docker/scripts/keycloak-setup.sh
@@ -2,6 +2,12 @@
 set -e
 KEYCLOAK_SETUP_VERSION=1.0.28
 KEYCLOAK_SEED_FILE=${KEYCLOAK_SEED_FILE:-tools/keycloak_setup/dev.yml}
+EXTRA_OPTS=""
+DEBUG_MODE=$(echo "$PINAKES_DEBUG" | tr '[:upper:]' '[:lower:]')
+
+if [[ $DEBUG_MODE == "true" ]]; then
+    EXTRA_OPTS="-vvv"
+fi
 
 echo running > /startup/status
 
@@ -18,5 +24,5 @@ ansible-galaxy collection build tools/keycloak_setup/collection
 echo -e "\e[34m >>> Installing keycloak setup collections \e[97m"
 ansible-galaxy collection install community.general pinakes-keycloak_setup-"$KEYCLOAK_SETUP_VERSION".tar.gz
 echo -e "\e[34m >>> Configuring Keycloak \e[97m"
-ansible-playbook ${KEYCLOAK_SEED_FILE} -vvv
+ansible-playbook ${KEYCLOAK_SEED_FILE} ${EXTRA_OPTS}
 echo finished > /startup/status

--- a/tools/docker/scripts/keycloak-setup.sh
+++ b/tools/docker/scripts/keycloak-setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 KEYCLOAK_SETUP_VERSION=1.0.28
+KEYCLOAK_SEED_FILE=${KEYCLOAK_SEED_FILE:-tools/keycloak_setup/dev.yml}
 
 echo running > /startup/status
 
@@ -17,7 +18,5 @@ ansible-galaxy collection build tools/keycloak_setup/collection
 echo -e "\e[34m >>> Installing keycloak setup collections \e[97m"
 ansible-galaxy collection install community.general pinakes-keycloak_setup-"$KEYCLOAK_SETUP_VERSION".tar.gz
 echo -e "\e[34m >>> Configuring Keycloak \e[97m"
-ansible-playbook tools/keycloak_setup/dev.yml -vvv
-
-ansible-playbook -vvv tools/keycloak_setup/dev.yml
+ansible-playbook ${KEYCLOAK_SEED_FILE} -vvv
 echo finished > /startup/status

--- a/tools/keycloak_setup/qa.yml
+++ b/tools/keycloak_setup/qa.yml
@@ -1,0 +1,121 @@
+---
+- hosts: localhost
+  vars:
+    verify_keycloak_ssl: false
+    seed_keycloak: true
+    seed_groups:
+      - name: catalog-admins
+        clientRoles:
+          - catalog-admin
+
+      - name: approval-admins
+        clientRoles:
+          - approval-admin
+
+      - name: users-approvers
+        clientRoles:
+          - catalog-user
+          - approval-approver
+
+      - name: admins-approvers
+        clientRoles:
+          - catalog-admin
+          - approval-approver
+
+      - name: users-approvers_admins
+        clientRoles:
+          - approval-admin
+          - catalog-user
+
+      - name: Information Technology - Sample
+        clientRoles:
+          - catalog-admin
+          - approval-admin
+
+      - name: Marketing - Sample
+        clientRoles:
+          - catalog-user
+
+      - name: Finance - Sample
+        clientRoles:
+          - approval-approver
+
+    seed_users:
+      - username: catalog-admin
+        firstName: Betty
+        lastName: ""
+        email: Betty@example.com
+        enabled: true
+        credentials:
+          - type: "password"
+            value: "password"
+        groups:
+          - catalog-admins
+
+      - username: approval-admin
+        firstName: dino
+        lastName: ""
+        email: dino@example.com
+        enabled: true
+        credentials:
+          - type: "password"
+            value: "password"
+        groups:
+          - approval-admins
+
+      - username: user-approver
+        firstName: bamm-bamm
+        lastName: ""
+        email: bamm@example.com
+        enabled: true
+        credentials:
+          - type: "password"
+            value: "password"
+        groups:
+          - users-approvers
+
+      - username: admin-approver
+        firstName: peebles
+        lastName: ""
+        email: peebles@example.com
+        enabled: true
+        credentials:
+          - type: "password"
+            value: "password"
+        groups:
+          - admins-approvers
+
+      - username: fred.sample
+        firstName: Fred
+        lastName: Sample
+        email: fred@example.com
+        enabled: true
+        credentials:
+          - type: "password"
+            value: "fred"
+        groups:
+          - Information Technology - Sample
+
+      - username: barney.sample
+        firstName: Barney
+        lastName: Sample
+        email: barney@example.com
+        enabled: true
+        credentials:
+          - type: "password"
+            value: "barney"
+        groups:
+          - Marketing - Sample
+
+      - username: wilma.sample
+        firstName: Wilma
+        lastName: Sample
+        email: wilma@example.com
+        enabled: true
+        credentials:
+          - type: "password"
+            value: "wilma"
+        groups:
+          - Finance - Sample
+  roles:
+    - pinakes.keycloak_setup.setup


### PR DESCRIPTION
- Add the ability to override the users and groups seeded by keycloak setup. 
- Fix a bug where we were running the command twice. 
- Add a new file with an extended set of users and groups. This is required by the QA team to cover more cases for RBAC testing. 