### PR TITLE
Lint: Add flake8-comprehensions plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -45,7 +45,7 @@ DUMMY_ACCESS_TOKEN = {
 def normal_user():
     user, _ = User.objects.get_or_create(
         username="normal",
-        defaults=dict(is_superuser=False, password="normal"),
+        defaults={"is_superuser": False, "password": "normal"},
     )
     return user
 
@@ -54,12 +54,12 @@ def normal_user():
 def admin():
     user, _ = User.objects.get_or_create(
         username="admin",
-        defaults=dict(
-            is_superuser=True,
-            password="admin",
-            first_name="Ansible",
-            last_name="Catalog",
-        ),
+        defaults={
+            "is_superuser": True,
+            "password": "admin",
+            "first_name": "Ansible",
+            "last_name": "Catalog",
+        },
     )
     return user
 

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,3 +1,4 @@
 black
 flake8
 flake8-bugbear
+flake8-comprehensions

--- a/pinakes/main/analytics/tests/test_analytics_collectors.py
+++ b/pinakes/main/analytics/tests/test_analytics_collectors.py
@@ -101,7 +101,7 @@ def test_source_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -134,7 +134,7 @@ def test_service_offering_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -168,7 +168,7 @@ def test_service_offering_node_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -198,7 +198,7 @@ def test_service_instance_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -229,7 +229,7 @@ def test_service_inventories_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -258,7 +258,7 @@ def test_portfolio_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -287,7 +287,7 @@ def test_portfolio_item_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -320,7 +320,7 @@ def test_order_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -349,7 +349,7 @@ def test_order_item_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -386,7 +386,7 @@ def test_approval_request_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -415,7 +415,7 @@ def test_service_plan_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -445,7 +445,7 @@ def test_template_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -471,7 +471,7 @@ def test_workflow_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -500,7 +500,7 @@ def test_request_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -537,7 +537,7 @@ def test_action_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -572,7 +572,7 @@ def test_tag_link_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",
@@ -604,7 +604,7 @@ def test_group_table_collector(sqlite_copy_expert):
             reader = csv.reader(f)
 
             header = next(reader)
-            lines = [line for line in reader]
+            lines = list(reader)
 
             assert header == [
                 "id",

--- a/pinakes/main/approval/services/process_root_request.py
+++ b/pinakes/main/approval/services/process_root_request.py
@@ -71,7 +71,7 @@ class ProcessRootRequest:
         sub_groups = self.request.subrequests.order_by("id").values(
             "group_name"
         )
-        all_names = ",".join(map(lambda x: x["group_name"], sub_groups))
+        all_names = ",".join(x["group_name"] for x in sub_groups)
         self.request.group_name = all_names
         self.request.save()
 

--- a/pinakes/main/approval/validations.py
+++ b/pinakes/main/approval/validations.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("approval")
 def validate_approver_groups(group_refs, raise_error=True):
     """Validate group permissions before they are assigned to a workflow"""
 
-    uuids = map(lambda ref: ref["uuid"], group_refs)
+    uuids = [ref["uuid"] for ref in group_refs]
     if raise_error and len(set(uuids)) < len(group_refs):
         raise DuplicatedUuidException()
 

--- a/pinakes/main/catalog/services/create_portfolio_item.py
+++ b/pinakes/main/catalog/services/create_portfolio_item.py
@@ -83,14 +83,11 @@ class CreatePortfolioItem:
         )
 
     def _create_fields(self):
-        service_offering_columns = [
+        service_offering_columns = {
             field.name for field in self.service_offering._meta.get_fields()
-        ]
-        portfolio_item_columns = list(
-            set([field.name for field in PortfolioItem._meta.get_fields()])
-            - set(self.IGNORE_FIELDS)
-        )
+        }
+        portfolio_item_columns = {
+            field.name for field in PortfolioItem._meta.get_fields()
+        } - set(self.IGNORE_FIELDS)
 
-        return list(
-            set(service_offering_columns) & set(portfolio_item_columns)
-        )
+        return list(service_offering_columns & portfolio_item_columns)

--- a/pinakes/main/common/tasks.py
+++ b/pinakes/main/common/tasks.py
@@ -70,12 +70,12 @@ def sync_external_groups():
         for parent_id, group in iter_groups(all_groups):
             obj, created = Group.objects.update_or_create(
                 id=group.id,
-                defaults=dict(
-                    name=group.name,
-                    path=group.path,
-                    last_sync_time=sync_time,
-                    parent_id=parent_id,
-                ),
+                defaults={
+                    "name": group.name,
+                    "path": group.path,
+                    "last_sync_time": sync_time,
+                    "parent_id": parent_id,
+                },
             )
 
             if created:
@@ -107,7 +107,7 @@ def clear_sessions():
 
 
 def _manage_roles(obj, group_roles):
-    existing_role_names = set(role.name for role in obj.roles.all())
+    existing_role_names = {role.name for role in obj.roles.all()}
     new_role_names = group_roles - existing_role_names
 
     roles = []


### PR DESCRIPTION
## Install and enable `flake8-comprehensions` plugin
A `flake8` plugin that helps you writing better list/set/dict comprehensions.
For the list of warnings see https://github.com/adamchainz/flake8-comprehensions#rules

## Fix flake8-comprehensions issues

### `C401` Unnecessary generator - rewrite as a set comprehension.
Example: `./pinakes/main/common/tasks.py:110:27:`
```
    existing_role_names = set(role.name for role in obj.roles.all())
                          ^
```
### `C403` Unnecessary list comprehension - rewrite as a set comprehension.
Example: `./pinakes/main/catalog/services/create_portfolio_item.py:90:13:`
```
            set([field.name for field in PortfolioItem._meta.get_fields()])
            ^
```
### `C408` Unnecessary dict call - rewrite as a literal.
Example: `./conftest.py:48:18`
```
        defaults=dict(is_superuser=False, password="normal"),
                 ^
```

### `C416` Unnecessary list comprehension - rewrite using list().
Example: `./pinakes/main/analytics/tests/test_analytics_collectors.py:104:21:`
```
            lines = [line for line in reader]
                    ^
```
### `C417` Unnecessary use of map - use a generator expression instead.
Example `./pinakes/main/approval/services/process_root_request.py:74:30:`
```
        all_names = ",".join(map(lambda x: x["group_name"], sub_groups))
                             ^
```