### PR TITLE
[SSP-2845] Fix tests when running pytest with PostgreSQL

### DIFF
--- a/pinakes/main/approval/tests/services/test_link_workflow.py
+++ b/pinakes/main/approval/tests/services/test_link_workflow.py
@@ -23,7 +23,7 @@ def test_taglink_workflow_add_remove():
 
     assert TagLink.objects.count() == 1
     assert portfolio.tags.count() == 1
-    assert portfolio.tags.first().name == f"/approval/workflows={portfolio.id}"
+    assert portfolio.tags.first().name == f"/approval/workflows={workflow.id}"
 
     LinkWorkflow(workflow, resource_obj).process(LinkWorkflow.Operation.REMOVE)
 

--- a/pinakes/main/approval/tests/unit/test_templates.py
+++ b/pinakes/main/approval/tests/unit/test_templates.py
@@ -19,13 +19,9 @@ class TestTemplate:
 
         tenant = TenantFactory()
         title = "fred"
-        template = TemplateFactory(tenant=tenant, title=title)
-        with pytest.raises(IntegrityError) as excinfo:
+        TemplateFactory(tenant=tenant, title=title)
+        with pytest.raises(IntegrityError):
             TemplateFactory(tenant=tenant, title=title)
-        assert (
-            "UNIQUE constraint failed:"
-            f" {template._meta.app_label}_template.title" in str(excinfo.value)
-        )
 
     @pytest.mark.django_db
     def test_empty_template_title(self):

--- a/pinakes/main/approval/tests/unit/test_workflows.py
+++ b/pinakes/main/approval/tests/unit/test_workflows.py
@@ -25,14 +25,8 @@ class TestWorkflows:
 
         tenant = TenantFactory()
         template = TemplateFactory(tenant=tenant)
-        with pytest.raises(IntegrityError) as excinfo:
+        with pytest.raises(IntegrityError):
             WorkflowFactory(tenant=tenant, template=template, name="")
-
-        assert (
-            "CHECK constraint failed:"
-            f" {template._meta.app_label}_workflow_name_empty"
-            in str(excinfo.value)
-        )
 
     @pytest.mark.django_db
     def test_duplicate_workflow_name(self):
@@ -42,13 +36,8 @@ class TestWorkflows:
         template = TemplateFactory(tenant=tenant)
         name = "fred"
         WorkflowFactory(tenant=tenant, template=template, name=name)
-        with pytest.raises(IntegrityError) as excinfo:
+        with pytest.raises(IntegrityError):
             WorkflowFactory(tenant=tenant, template=template, name=name)
-
-        assert (
-            "UNIQUE constraint failed:"
-            f" {template._meta.app_label}_workflow.name" in str(excinfo.value)
-        )
 
     @pytest.mark.django_db
     def test_duplicate_internal_sequence(self):
@@ -59,13 +48,7 @@ class TestWorkflows:
         WorkflowFactory(
             tenant=tenant, template=template, internal_sequence=Decimal(3)
         )
-        with pytest.raises(IntegrityError) as excinfo:
+        with pytest.raises(IntegrityError):
             WorkflowFactory(
                 tenant=tenant, template=template, internal_sequence=Decimal(3)
             )
-
-        assert (
-            "UNIQUE constraint failed:"
-            f" {template._meta.app_label}_workflow.internal_sequence"
-            in str(excinfo.value)
-        )

--- a/pinakes/main/catalog/tests/services/test_start_order_item.py
+++ b/pinakes/main/catalog/tests/services/test_start_order_item.py
@@ -30,7 +30,7 @@ from pinakes.main.catalog.tests.factories import (
 @pytest.mark.django_db
 def test_place_order_item(mocker):
     order = OrderFactory()
-    OrderItemFactory(state=OrderItem.State.PENDING, order=order)
+    order_item1 = OrderItemFactory(state=OrderItem.State.PENDING, order=order)
     OrderItemFactory(state=OrderItem.State.APPROVED, order=order)
 
     mocker.patch.object(ProvisionOrderItem, "process", return_value=None)
@@ -39,7 +39,7 @@ def test_place_order_item(mocker):
 
     assert (
         str(ProgressMessage.objects.first())
-        == "Submitting Order Item 1 for provisioning"
+        == f"Submitting Order Item {order_item1.id} for provisioning"
     )
 
 

--- a/pinakes/main/catalog/tests/services/test_start_order_item.py
+++ b/pinakes/main/catalog/tests/services/test_start_order_item.py
@@ -30,7 +30,7 @@ from pinakes.main.catalog.tests.factories import (
 @pytest.mark.django_db
 def test_place_order_item(mocker):
     order = OrderFactory()
-    order_item1 = OrderItemFactory(state=OrderItem.State.PENDING, order=order)
+    order_item = OrderItemFactory(state=OrderItem.State.PENDING, order=order)
     OrderItemFactory(state=OrderItem.State.APPROVED, order=order)
 
     mocker.patch.object(ProvisionOrderItem, "process", return_value=None)
@@ -39,7 +39,7 @@ def test_place_order_item(mocker):
 
     assert (
         str(ProgressMessage.objects.first())
-        == f"Submitting Order Item {order_item1.id} for provisioning"
+        == f"Submitting Order Item {order_item.id} for provisioning"
     )
 
 

--- a/pinakes/main/catalog/tests/unit/test_order_items.py
+++ b/pinakes/main/catalog/tests/unit/test_order_items.py
@@ -39,17 +39,12 @@ def test_duplicate_orderitem_name():
     order = OrderFactory(tenant=tenant)
     portfolio_item = PortfolioItemFactory(tenant=tenant)
     OrderItemFactory(tenant=tenant, order=order, portfolio_item=portfolio_item)
-    with pytest.raises(IntegrityError) as excinfo:
+    with pytest.raises(IntegrityError):
         OrderItemFactory(
             tenant=tenant,
             order=order,
             portfolio_item=portfolio_item,
         )
-
-    assert (
-        f"UNIQUE constraint failed: {order._meta.app_label}_orderitem.name"
-        in str(excinfo.value)
-    )
 
 
 @pytest.mark.django_db

--- a/pinakes/main/catalog/tests/unit/test_portfolio_items.py
+++ b/pinakes/main/catalog/tests/unit/test_portfolio_items.py
@@ -25,14 +25,8 @@ class TestPortfolioItems:
 
         tenant = TenantFactory()
         portfolio = PortfolioFactory(tenant=tenant)
-        with pytest.raises(IntegrityError) as excinfo:
+        with pytest.raises(IntegrityError):
             PortfolioItemFactory(tenant=tenant, portfolio=portfolio, name="")
-
-        assert (
-            "CHECK constraint failed:"
-            f" {portfolio._meta.app_label}_portfolioitem_name_empty"
-            in str(excinfo.value)
-        )
 
     @pytest.mark.django_db
     def test_portfolio_metadata(self, api_request):

--- a/pinakes/main/catalog/tests/unit/test_portfolios.py
+++ b/pinakes/main/catalog/tests/unit/test_portfolios.py
@@ -26,14 +26,9 @@ class TestPortfolios:
 
         tenant = TenantFactory()
         name = "fred"
-        portfolio = PortfolioFactory(tenant=tenant, name=name)
-        with pytest.raises(IntegrityError) as excinfo:
+        PortfolioFactory(tenant=tenant, name=name)
+        with pytest.raises(IntegrityError):
             PortfolioFactory(tenant=tenant, name=name)
-        assert (
-            "UNIQUE constraint failed:"
-            f" {portfolio._meta.app_label}_portfolio.name"
-            in str(excinfo.value)
-        )
 
     @pytest.mark.django_db
     def test_empty_portfolio_name(self):


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2845

Found the following issues
1. The constraint exception messages differ between DB's
   The string in Postgres doesn't match the String in SQLite
2. Incorrect ID's were being used in a couple of places

If you want to run tests using a locally installed PostgreSQL DB
please set the following env vars before running pytest

* export DJANGO_SETTINGS_MODULE=pinakes.settings.defaults
* export PINAKES_SECRET_KEY=abcdef
* export PINAKES_POSTGRES_USER=<<PG_USER>>
* export PINAKES_POSTGRES_PASSWORD=<<PG_PASSWORD>>
* export PINAKES_POSTGRES_SSL_MODE=disable