### PR TITLE
Misc: Fix whitespaces in docstrings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-""" pytest fixtures """
+"""pytest fixtures"""
 import contextlib
 import os
 import urllib.parse

--- a/pinakes/common/serializers.py
+++ b/pinakes/common/serializers.py
@@ -1,4 +1,4 @@
-""" Serializers for Tags """
+"""Serializers for Tags"""
 from rest_framework import serializers
 
 

--- a/pinakes/main/analytics/tasks.py
+++ b/pinakes/main/analytics/tasks.py
@@ -1,4 +1,4 @@
-""" Tasks for metrics collection """
+"""Tasks for metrics collection"""
 import logging
 import django_rq
 from rq import Queue

--- a/pinakes/main/analytics/tests/test_analytics_collectors.py
+++ b/pinakes/main/analytics/tests/test_analytics_collectors.py
@@ -1,4 +1,4 @@
-""" Tests for metrics collection """
+"""Tests for metrics collection"""
 import csv
 from datetime import timedelta
 import os

--- a/pinakes/main/approval/services/create_request.py
+++ b/pinakes/main/approval/services/create_request.py
@@ -1,4 +1,4 @@
-""" Create an approval request """
+"""Create an approval request"""
 import logging
 import django_rq
 from pinakes.main.approval.models import (

--- a/pinakes/main/approval/services/process_root_request.py
+++ b/pinakes/main/approval/services/process_root_request.py
@@ -1,4 +1,4 @@
-""" Process a root request """
+"""Process a root request"""
 import logging
 import django_rq
 

--- a/pinakes/main/approval/services/send_event.py
+++ b/pinakes/main/approval/services/send_event.py
@@ -1,4 +1,4 @@
-""" Send an event when a request changes it state """
+"""Send an event when a request changes it state"""
 import logging
 
 from pinakes.main.catalog.services.handle_approval_events import (

--- a/pinakes/main/approval/tasks.py
+++ b/pinakes/main/approval/tasks.py
@@ -1,4 +1,4 @@
-""" Background tasks for inventory """
+"""Background tasks for inventory"""
 import logging
 from rq import get_current_job
 from pinakes.main.approval.services.create_action import (

--- a/pinakes/main/approval/tests/functional/test_notification_end_points.py
+++ b/pinakes/main/approval/tests/functional/test_notification_end_points.py
@@ -1,4 +1,4 @@
-""" Module for testing Notification settings """
+"""Module for testing Notification settings"""
 import pytest
 from pinakes.main.approval.models import NotificationType
 from pinakes.main.approval.permissions import TemplatePermission

--- a/pinakes/main/approval/tests/functional/test_request_end_points.py
+++ b/pinakes/main/approval/tests/functional/test_request_end_points.py
@@ -1,4 +1,4 @@
-""" Module to test approval requests and actions """
+"""Module to test approval requests and actions"""
 import json
 import pytest
 from pinakes.main.tests.factories import default_tenant

--- a/pinakes/main/approval/tests/functional/test_template_end_points.py
+++ b/pinakes/main/approval/tests/functional/test_template_end_points.py
@@ -1,4 +1,4 @@
-""" Module for testing Approval Templates """
+"""Module for testing Approval Templates"""
 import json
 import pytest
 from pinakes.main.approval.tests.factories import (

--- a/pinakes/main/approval/tests/functional/test_workflow_end_points.py
+++ b/pinakes/main/approval/tests/functional/test_workflow_end_points.py
@@ -1,4 +1,4 @@
-""" Module to test approval workflows """
+"""Module to test approval workflows"""
 import json
 import pytest
 from pinakes.main.approval.tests.factories import (

--- a/pinakes/main/approval/tests/services/test_create_request.py
+++ b/pinakes/main/approval/tests/services/test_create_request.py
@@ -1,4 +1,4 @@
-""" Module to test creating requests """
+"""Module to test creating requests"""
 from unittest.mock import Mock
 import pytest
 from pinakes.main.tests.factories import default_tenant

--- a/pinakes/main/approval/tests/services/test_process_root_request.py
+++ b/pinakes/main/approval/tests/services/test_process_root_request.py
@@ -1,4 +1,4 @@
-""" Module to test processing root requests """
+"""Module to test processing root requests"""
 from unittest.mock import Mock, call
 import pytest
 from pinakes.main.approval.tests.factories import (

--- a/pinakes/main/approval/tests/test_validations.py
+++ b/pinakes/main/approval/tests/test_validations.py
@@ -1,4 +1,4 @@
-""" Test validation methods """
+"""Test validation methods"""
 import pytest
 from pinakes.main.approval import validations
 from pinakes.main.common.tests.factories import (

--- a/pinakes/main/approval/views.py
+++ b/pinakes/main/approval/views.py
@@ -1,4 +1,4 @@
-""" Default views for Approval."""
+"""Default views for Approval."""
 import logging
 
 from decimal import Decimal

--- a/pinakes/main/catalog/exceptions.py
+++ b/pinakes/main/catalog/exceptions.py
@@ -1,4 +1,4 @@
-"""Application specific exception classes""" ""
+"""Application specific exception classes"""
 from rest_framework import exceptions, status
 from django.utils.translation import gettext_lazy as _
 

--- a/pinakes/main/catalog/models.py
+++ b/pinakes/main/catalog/models.py
@@ -1,4 +1,4 @@
-""" This modules stores the definition of the Catalog model."""
+"""This modules stores the definition of the Catalog model."""
 import logging
 
 from django.utils.translation import gettext_lazy as _

--- a/pinakes/main/catalog/serializers.py
+++ b/pinakes/main/catalog/serializers.py
@@ -1,4 +1,4 @@
-""" Serializers for Catalog Model."""
+"""Serializers for Catalog Model."""
 from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 

--- a/pinakes/main/catalog/services/cancel_order.py
+++ b/pinakes/main/catalog/services/cancel_order.py
@@ -1,4 +1,4 @@
-""" Cancel an order request"""
+"""Cancel an order request"""
 import logging
 
 from django.utils.translation import gettext_lazy as _

--- a/pinakes/main/catalog/services/collect_tag_resources.py
+++ b/pinakes/main/catalog/services/collect_tag_resources.py
@@ -1,4 +1,4 @@
-""" Collection of tag resources. """
+"""Collection of tag resources."""
 import logging
 from django.utils.translation import gettext_lazy as _
 

--- a/pinakes/main/catalog/services/finish_order_item.py
+++ b/pinakes/main/catalog/services/finish_order_item.py
@@ -1,4 +1,4 @@
-""" Module to Finish Processing an OrderItem """
+"""Module to Finish Processing an OrderItem"""
 import logging
 
 from django.utils.translation import gettext_lazy as _

--- a/pinakes/main/catalog/services/handle_approval_events.py
+++ b/pinakes/main/catalog/services/handle_approval_events.py
@@ -1,4 +1,4 @@
-""" Handle approval events """
+"""Handle approval events"""
 import logging
 
 from django.utils import timezone

--- a/pinakes/main/catalog/services/provision_order_item.py
+++ b/pinakes/main/catalog/services/provision_order_item.py
@@ -1,4 +1,4 @@
-""" Start provisioning a Single order item """
+"""Start provisioning a Single order item"""
 
 from pinakes.main.inventory.services.start_tower_job import (
     StartTowerJob,

--- a/pinakes/main/catalog/services/start_order.py
+++ b/pinakes/main/catalog/services/start_order.py
@@ -1,4 +1,4 @@
-""" Approval Request State Transition """
+"""Approval Request State Transition"""
 
 import logging
 

--- a/pinakes/main/catalog/services/start_order_item.py
+++ b/pinakes/main/catalog/services/start_order_item.py
@@ -1,4 +1,4 @@
-""" Start processing the next order item """
+"""Start processing the next order item"""
 import logging
 from django.utils.translation import gettext_lazy as _
 

--- a/pinakes/main/catalog/services/submit_approval_request.py
+++ b/pinakes/main/catalog/services/submit_approval_request.py
@@ -1,4 +1,4 @@
-""" Create a request to Approval """
+"""Create a request to Approval"""
 import logging
 
 from django.utils.translation import gettext_lazy as _

--- a/pinakes/main/catalog/services/update_service_plans.py
+++ b/pinakes/main/catalog/services/update_service_plans.py
@@ -1,4 +1,4 @@
-""" A Service object to compare the Catalog service plan
+"""A Service object to compare the Catalog service plan
     with the Inventory service plan and if they are different
     Copy over the changes if the admin has not modified the schema
     if the admin has modified the schema then flag the service plan

--- a/pinakes/main/catalog/services/validate_order_item.py
+++ b/pinakes/main/catalog/services/validate_order_item.py
@@ -1,4 +1,4 @@
-""" Validate order item by its service plans. """
+"""Validate order item by its service plans."""
 
 from django.utils.translation import gettext_lazy as _
 

--- a/pinakes/main/catalog/tests/factories.py
+++ b/pinakes/main/catalog/tests/factories.py
@@ -1,4 +1,4 @@
-""" Factory for catalog objects """
+"""Factory for catalog objects"""
 from django.db.models.fields.files import ImageFieldFile, FileField
 import factory
 

--- a/pinakes/main/catalog/tests/functional/test_approval_request_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_approval_request_end_points.py
@@ -1,4 +1,4 @@
-""" Test order end points """
+"""Test order end points"""
 import pytest
 
 from pinakes.main.catalog.tests.factories import (

--- a/pinakes/main/catalog/tests/functional/test_order_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_order_end_points.py
@@ -1,4 +1,4 @@
-""" Test order end points """
+"""Test order end points"""
 import json
 import pytest
 

--- a/pinakes/main/catalog/tests/functional/test_order_item_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_order_item_end_points.py
@@ -1,4 +1,4 @@
-""" Module to test OrderItem end points """
+"""Module to test OrderItem end points"""
 import json
 import pytest
 

--- a/pinakes/main/catalog/tests/functional/test_portfolio_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_portfolio_end_points.py
@@ -1,4 +1,4 @@
-""" Test portfolio end points """
+"""Test portfolio end points"""
 import json
 import os
 import glob

--- a/pinakes/main/catalog/tests/functional/test_portfolio_tags_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_portfolio_tags_end_points.py
@@ -1,4 +1,4 @@
-""" Test for tagging  """
+"""Test for tagging"""
 import json
 import pytest
 

--- a/pinakes/main/catalog/tests/functional/test_progress_message_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_progress_message_end_points.py
@@ -1,4 +1,4 @@
-""" Test order end points """
+"""Test order end points"""
 import json
 import pytest
 

--- a/pinakes/main/catalog/tests/functional/test_service_plan_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_service_plan_end_points.py
@@ -1,4 +1,4 @@
-""" Test service_plan end points """
+"""Test service_plan end points"""
 import json
 from unittest import mock
 

--- a/pinakes/main/catalog/tests/functional/test_tenant_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_tenant_end_points.py
@@ -1,4 +1,4 @@
-""" Module to test Tenant end points """
+"""Module to test Tenant end points"""
 import json
 import pytest
 from pinakes.main.tests.factories import TenantFactory

--- a/pinakes/main/catalog/tests/services/test_cancel_order.py
+++ b/pinakes/main/catalog/tests/services/test_cancel_order.py
@@ -1,4 +1,4 @@
-""" Test on CancelOrder service """
+"""Test on CancelOrder service"""
 import pytest
 
 from pinakes.main.approval.models import Action, Request

--- a/pinakes/main/catalog/tests/services/test_collect_tag_resources.py
+++ b/pinakes/main/catalog/tests/services/test_collect_tag_resources.py
@@ -1,4 +1,4 @@
-""" Test on CollectTagResources """
+"""Test on CollectTagResources"""
 import pytest
 
 from pinakes.main.catalog.services.collect_tag_resources import (

--- a/pinakes/main/catalog/tests/services/test_compute_runtime_parameters.py
+++ b/pinakes/main/catalog/tests/services/test_compute_runtime_parameters.py
@@ -1,4 +1,4 @@
-""" Test population json template with input parameters """
+"""Test population json template with input parameters"""
 import pytest
 
 from pinakes.main.catalog.tests.factories import (

--- a/pinakes/main/catalog/tests/services/test_finish_order.py
+++ b/pinakes/main/catalog/tests/services/test_finish_order.py
@@ -1,4 +1,4 @@
-""" Test starting an order """
+"""Test starting an order"""
 
 import pytest
 

--- a/pinakes/main/catalog/tests/services/test_finish_order_item.py
+++ b/pinakes/main/catalog/tests/services/test_finish_order_item.py
@@ -1,4 +1,4 @@
-""" Test module for finishing an OrderItem """
+"""Test module for finishing an OrderItem"""
 import pytest
 from pinakes.main.catalog.tests.factories import (
     OrderItemFactory,

--- a/pinakes/main/catalog/tests/services/test_provision_order_item.py
+++ b/pinakes/main/catalog/tests/services/test_provision_order_item.py
@@ -1,4 +1,4 @@
-""" Test module for starting an OrderItem """
+"""Test module for starting an OrderItem"""
 from unittest.mock import Mock
 from unittest.mock import patch
 import pytest

--- a/pinakes/main/catalog/tests/services/test_refresh_service_plan.py
+++ b/pinakes/main/catalog/tests/services/test_refresh_service_plan.py
@@ -1,4 +1,4 @@
-""" Test population json template with input parameters """
+"""Test population json template with input parameters"""
 import pytest
 import copy
 

--- a/pinakes/main/catalog/tests/services/test_start_order.py
+++ b/pinakes/main/catalog/tests/services/test_start_order.py
@@ -1,4 +1,4 @@
-""" Test starting an order """
+"""Test starting an order"""
 
 import pytest
 

--- a/pinakes/main/catalog/tests/services/test_start_order_item.py
+++ b/pinakes/main/catalog/tests/services/test_start_order_item.py
@@ -1,4 +1,4 @@
-""" Start ordering an item """
+"""Start ordering an item"""
 
 import pytest
 from unittest import mock

--- a/pinakes/main/catalog/tests/services/test_submit_approval_request.py
+++ b/pinakes/main/catalog/tests/services/test_submit_approval_request.py
@@ -1,4 +1,4 @@
-""" Test on CreateApprovalRequest service """
+"""Test on CreateApprovalRequest service"""
 import pytest
 
 from pinakes.main.approval.models import Request

--- a/pinakes/main/catalog/tests/services/test_validate_order_item.py
+++ b/pinakes/main/catalog/tests/services/test_validate_order_item.py
@@ -1,4 +1,4 @@
-""" Test population json template with input parameters """
+"""Test population json template with input parameters"""
 import pytest
 
 from pinakes.main.catalog.exceptions import (

--- a/pinakes/main/catalog/tests/test_utils.py
+++ b/pinakes/main/catalog/tests/test_utils.py
@@ -1,4 +1,4 @@
-""" Test comparison of the two schemas """
+"""Test comparison of the two schemas"""
 
 from pinakes.main.catalog.utils import (
     compare_schemas,

--- a/pinakes/main/catalog/tests/unit/test_order_items.py
+++ b/pinakes/main/catalog/tests/unit/test_order_items.py
@@ -1,4 +1,4 @@
-""" Test on OrderItem """
+"""Test on OrderItem"""
 import pytest
 from django.db import IntegrityError
 

--- a/pinakes/main/catalog/tests/unit/test_orders.py
+++ b/pinakes/main/catalog/tests/unit/test_orders.py
@@ -1,4 +1,4 @@
-""" Test on Order """
+"""Test on Order"""
 import pytest
 
 from pinakes.main.catalog.models import ProgressMessage

--- a/pinakes/main/catalog/views.py
+++ b/pinakes/main/catalog/views.py
@@ -1,4 +1,4 @@
-""" Default views for Catalog."""
+"""Default views for Catalog."""
 
 import logging
 

--- a/pinakes/main/inventory/exceptions.py
+++ b/pinakes/main/inventory/exceptions.py
@@ -1,4 +1,4 @@
-"""Application specific exception classes""" ""
+"""Application specific exception classes"""
 from rest_framework import exceptions, status
 from django.utils.translation import gettext_lazy as _
 

--- a/pinakes/main/inventory/models.py
+++ b/pinakes/main/inventory/models.py
@@ -1,4 +1,4 @@
-""" This module stores the data model for Catalog Inventory
+"""This module stores the data model for Catalog Inventory
     The inventory is basically a collection of objects from the
     Automation Controller (Ansible Tower). The objects that we collect
     are

--- a/pinakes/main/inventory/serializers.py
+++ b/pinakes/main/inventory/serializers.py
@@ -1,4 +1,4 @@
-""" Serializers for Inventory Model."""
+"""Serializers for Inventory Model."""
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import gettext_noop
 from rest_framework import serializers

--- a/pinakes/main/inventory/services/collect_inventory_tags.py
+++ b/pinakes/main/inventory/services/collect_inventory_tags.py
@@ -1,4 +1,4 @@
-""" Collect Inventory Tags for a given service offering """
+"""Collect Inventory Tags for a given service offering"""
 from django.utils.translation import gettext_lazy as _
 from pinakes.main.inventory.models import (
     ServiceOffering,

--- a/pinakes/main/inventory/services/get_service_offering.py
+++ b/pinakes/main/inventory/services/get_service_offering.py
@@ -1,4 +1,4 @@
-""" Get service plan for a given service plan id """
+"""Get service plan for a given service plan id"""
 
 from django.utils.translation import gettext_lazy as _
 from pinakes.main.inventory.models import (

--- a/pinakes/main/inventory/services/start_tower_job.py
+++ b/pinakes/main/inventory/services/start_tower_job.py
@@ -1,4 +1,4 @@
-""" Module to start a Tower Job using Django_rq """
+"""Module to start a Tower Job using Django_rq"""
 import django_rq
 from pinakes.main.inventory.models import (
     ServiceOffering,

--- a/pinakes/main/inventory/task_utils/check_source_availability.py
+++ b/pinakes/main/inventory/task_utils/check_source_availability.py
@@ -1,4 +1,4 @@
-""" Task to Refresh Inventory from the Tower """
+"""Task to Refresh Inventory from the Tower"""
 import logging
 from django.db import transaction
 from django.utils import timezone

--- a/pinakes/main/inventory/task_utils/controller_config.py
+++ b/pinakes/main/inventory/task_utils/controller_config.py
@@ -1,5 +1,4 @@
-""" Get Controller Config Information
-"""
+"""Get Controller Config Information"""
 import logging
 
 logger = logging.getLogger("inventory")

--- a/pinakes/main/inventory/task_utils/launch_job.py
+++ b/pinakes/main/inventory/task_utils/launch_job.py
@@ -1,4 +1,4 @@
-""" Task to Launch a Job in Tower and wait for it to end"""
+"""Task to Launch a Job in Tower and wait for it to end"""
 import time
 import logging
 from django.utils.translation import gettext_lazy as _

--- a/pinakes/main/inventory/task_utils/refresh_inventory.py
+++ b/pinakes/main/inventory/task_utils/refresh_inventory.py
@@ -1,4 +1,4 @@
-""" Task to Refresh Inventory from the Tower """
+"""Task to Refresh Inventory from the Tower"""
 import logging
 import traceback
 from django.db import transaction

--- a/pinakes/main/inventory/task_utils/service_inventory_import.py
+++ b/pinakes/main/inventory/task_utils/service_inventory_import.py
@@ -1,4 +1,4 @@
-""" ServiceInventoryImport module imports the Inventory
+"""ServiceInventoryImport module imports the Inventory
     object from Ansible Tower. It handles adds, updates
     and deletes.
 """

--- a/pinakes/main/inventory/task_utils/service_offering_import.py
+++ b/pinakes/main/inventory/task_utils/service_offering_import.py
@@ -1,4 +1,4 @@
-""" ServiceOfferingImporter module imports job Templates and
+"""ServiceOfferingImporter module imports job Templates and
     Workflow Job templates from the tower
 """
 import logging

--- a/pinakes/main/inventory/task_utils/service_offering_node_import.py
+++ b/pinakes/main/inventory/task_utils/service_offering_node_import.py
@@ -1,4 +1,4 @@
-""" Import Workflow Job template nodes from Tower """
+"""Import Workflow Job template nodes from Tower"""
 
 import dateutil.parser
 from pinakes.main.inventory.models import (

--- a/pinakes/main/inventory/task_utils/service_plan_import.py
+++ b/pinakes/main/inventory/task_utils/service_plan_import.py
@@ -1,4 +1,4 @@
-""" ServicePlanImport module imports the SurveySpec
+"""ServicePlanImport module imports the SurveySpec
     from Ansible Tower. It converts the Spec to DDF
     format and saves it in the DB
 """

--- a/pinakes/main/inventory/task_utils/spec_to_ddf.py
+++ b/pinakes/main/inventory/task_utils/spec_to_ddf.py
@@ -1,4 +1,4 @@
-""" Convert a Tower Survey Spec to
+"""Convert a Tower Survey Spec to
     Data Driven Forms (DDF) format
 """
 

--- a/pinakes/main/inventory/task_utils/tower_api.py
+++ b/pinakes/main/inventory/task_utils/tower_api.py
@@ -1,4 +1,4 @@
-""" Tower API module interacts using the REST API to
+"""Tower API module interacts using the REST API to
     1. Get a single object
     2. Get multiple objects with pagination info
     3. POST a Job Template/Workflow

--- a/pinakes/main/inventory/tasks.py
+++ b/pinakes/main/inventory/tasks.py
@@ -1,4 +1,4 @@
-""" Background tasks for inventory """
+"""Background tasks for inventory"""
 import logging
 from rq import get_current_job
 

--- a/pinakes/main/inventory/tests/factories.py
+++ b/pinakes/main/inventory/tests/factories.py
@@ -1,4 +1,4 @@
-""" Factory for the Inventory objects """
+"""Factory for the Inventory objects"""
 import factory
 from django.utils import timezone
 from pinakes.main.models import Source

--- a/pinakes/main/inventory/tests/functional/test_service_instance_endpoints.py
+++ b/pinakes/main/inventory/tests/functional/test_service_instance_endpoints.py
@@ -1,4 +1,4 @@
-""" Module to test ServiceInstance end points """
+"""Module to test ServiceInstance end points"""
 import json
 import pytest
 from pinakes.main.inventory.tests.factories import (

--- a/pinakes/main/inventory/tests/functional/test_service_inventory_endpoints.py
+++ b/pinakes/main/inventory/tests/functional/test_service_inventory_endpoints.py
@@ -1,4 +1,4 @@
-""" Module to test ServiceInventory end points """
+"""Module to test ServiceInventory end points"""
 import json
 import pytest
 

--- a/pinakes/main/inventory/tests/functional/test_service_offering_endpoints.py
+++ b/pinakes/main/inventory/tests/functional/test_service_offering_endpoints.py
@@ -1,4 +1,4 @@
-""" Module to test ServiceOffering end points """
+"""Module to test ServiceOffering end points"""
 import json
 import pytest
 

--- a/pinakes/main/inventory/tests/functional/test_service_plan_endpoints.py
+++ b/pinakes/main/inventory/tests/functional/test_service_plan_endpoints.py
@@ -1,4 +1,4 @@
-""" Module to test ServicePlan end points """
+"""Module to test ServicePlan end points"""
 import json
 import pytest
 from pinakes.main.inventory.tests.factories import (

--- a/pinakes/main/inventory/tests/functional/test_source_endpoints.py
+++ b/pinakes/main/inventory/tests/functional/test_source_endpoints.py
@@ -1,4 +1,4 @@
-""" Module to test Source end points """
+"""Module to test Source end points"""
 from unittest.mock import Mock
 import json
 import pytest

--- a/pinakes/main/inventory/tests/services/test_collect_inventory_tags.py
+++ b/pinakes/main/inventory/tests/services/test_collect_inventory_tags.py
@@ -1,4 +1,4 @@
-""" Module to test Collection of inventory tags """
+"""Module to test Collection of inventory tags"""
 import pytest
 from pinakes.main.inventory.tests.factories import (
     ServiceInventoryFactory,

--- a/pinakes/main/inventory/tests/task_utils/test_check_source_availability.py
+++ b/pinakes/main/inventory/tests/task_utils/test_check_source_availability.py
@@ -1,4 +1,4 @@
-""" Module to test the source availability check. """
+"""Module to test the source availability check."""
 from unittest import mock
 
 import pytest

--- a/pinakes/main/inventory/tests/task_utils/test_controller_config.py
+++ b/pinakes/main/inventory/tests/task_utils/test_controller_config.py
@@ -1,4 +1,4 @@
-""" Test module for ControllerConfig  """
+"""Test module for ControllerConfig"""
 from unittest.mock import Mock
 
 from pinakes.main.inventory.task_utils.controller_config import (

--- a/pinakes/main/inventory/tests/task_utils/test_launch_job.py
+++ b/pinakes/main/inventory/tests/task_utils/test_launch_job.py
@@ -1,4 +1,4 @@
-""" Module to Test Launching of Job """
+"""Module to Test Launching of Job"""
 from unittest.mock import patch
 import pytest
 from pinakes.main.inventory.task_utils.launch_job import (

--- a/pinakes/main/inventory/tests/task_utils/test_refresh_inventory.py
+++ b/pinakes/main/inventory/tests/task_utils/test_refresh_inventory.py
@@ -1,4 +1,4 @@
-""" Module to test the Refresh Inventory. """
+"""Module to test the Refresh Inventory."""
 from unittest.mock import patch
 import pytest
 from pinakes.main.tests.factories import TenantFactory

--- a/pinakes/main/inventory/tests/task_utils/test_service_inventory_import.py
+++ b/pinakes/main/inventory/tests/task_utils/test_service_inventory_import.py
@@ -1,4 +1,4 @@
-""" Test module for ServiceInventoryImport  """
+"""Test module for ServiceInventoryImport"""
 from unittest.mock import Mock
 import pytest
 from django.core.exceptions import ObjectDoesNotExist

--- a/pinakes/main/inventory/tests/task_utils/test_service_offering_import.py
+++ b/pinakes/main/inventory/tests/task_utils/test_service_offering_import.py
@@ -1,4 +1,4 @@
-""" Test module for ServiceOfferingImport  """
+"""Test module for ServiceOfferingImport"""
 from unittest.mock import Mock
 
 import pytest

--- a/pinakes/main/inventory/tests/task_utils/test_service_plan_import.py
+++ b/pinakes/main/inventory/tests/task_utils/test_service_plan_import.py
@@ -1,4 +1,4 @@
-""" Module to test import of ServicePlan (tower SurveySpec). """
+"""Module to test import of ServicePlan (tower SurveySpec)."""
 
 import json
 import hashlib

--- a/pinakes/main/inventory/tests/task_utils/test_tower_api.py
+++ b/pinakes/main/inventory/tests/task_utils/test_tower_api.py
@@ -1,4 +1,4 @@
-""" Module to test GET/POST to Tower """
+"""Module to test GET/POST to Tower"""
 import pytest
 import responses
 import requests

--- a/pinakes/main/models.py
+++ b/pinakes/main/models.py
@@ -1,4 +1,4 @@
-""" This module stores the base models needed for Catalog. """
+"""This module stores the base models needed for Catalog."""
 from django.db import models
 from django.db.utils import OperationalError
 from django.db.models.functions import Length

--- a/pinakes/main/tests/factories.py
+++ b/pinakes/main/tests/factories.py
@@ -1,4 +1,4 @@
-""" Factory for catalog objects """
+"""Factory for catalog objects"""
 import factory
 from django.contrib.auth import get_user_model
 

--- a/pinakes/settings/development.py
+++ b/pinakes/settings/development.py
@@ -1,4 +1,4 @@
-""" Development Settings
+"""Development Settings
     When running pytest SQLite is used as Database
     Supports local settings in pinakes/settings/local*.py
 """


### PR DESCRIPTION
Fix flake8-docstrings issue `D210`:

**`D210` No whitespaces allowed surrounding docstring text**

```
""" Module to test ServiceInventory end points """
^
```