### PR TITLE
Fix migrations dependency on actual model

### DIFF
--- a/pinakes/main/migrations/0030_create_email_template.py
+++ b/pinakes/main/migrations/0030_create_email_template.py
@@ -1,21 +1,21 @@
-from django.db import migrations, transaction
-from pinakes.main.models import Tenant
+from django.db import migrations
 
 
 def create_template(apps, schema_editor):
+    Tenant = apps.get_model("main", "Tenant")
     Template = apps.get_model("main", "Template")
     db_alias = schema_editor.connection.alias
 
-    with transaction.atomic():
-        tenant = Tenant.current()
-        Template.objects.using(db_alias).create(
-            title="Built-in Email Notification",
-            description=(
-                "Notify approvers by HTML emails with ebedded links for"
-                " actions"
-            ),
-            tenant_id=tenant.id,
-        )
+    tenant, _ = Tenant.objects.using(db_alias).get_or_create(
+        external_tenant="default"
+    )
+    Template.objects.using(db_alias).create(
+        title="Built-in Email Notification",
+        description=(
+            "Notify approvers by HTML emails with ebedded links for actions"
+        ),
+        tenant_id=tenant.id,
+    )
 
 
 class Migration(migrations.Migration):

--- a/pinakes/main/migrations/0031_create_default_source.py
+++ b/pinakes/main/migrations/0031_create_default_source.py
@@ -1,21 +1,22 @@
-from django.db import migrations, transaction
-from pinakes.main.models import Tenant
+from django.db import migrations
 
 
 def create_source(apps, schema_editor):
     """create a default source if none exists"""
+    Tenant = apps.get_model("main", "Tenant")
     Source = apps.get_model("main", "Source")
     db_alias = schema_editor.connection.alias
 
     if Source.objects.using(db_alias).count() > 0:
         return
 
-    with transaction.atomic():
-        tenant = Tenant.current()
-        Source.objects.using(db_alias).create(
-            name="Automation Controller",
-            tenant_id=tenant.id,
-        )
+    tenant, _ = Tenant.objects.using(db_alias).get_or_create(
+        external_tenant="default"
+    )
+    Source.objects.using(db_alias).create(
+        name="Automation Controller",
+        tenant_id=tenant.id,
+    )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Migrations must not depend on actual models, since any change
to a dependant model can potentially break migrations.