### PR TITLE
[SSP-2956] Move template_id from path variable to POST/PATCH body

### DIFF
--- a/pinakes/main/approval/serializers.py
+++ b/pinakes/main/approval/serializers.py
@@ -124,7 +124,7 @@ class WorkflowSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         )
-        read_only_fields = ("created_at", "updated_at", "template")
+        read_only_fields = ("created_at", "updated_at")
 
     def validate_group_refs(self, value):
         serializer = GroupRefSerializer(many=True, data=value)

--- a/pinakes/main/approval/urls.py
+++ b/pinakes/main/approval/urls.py
@@ -33,11 +33,11 @@ templates.register(
 urls_views["template-workflow-detail"] = None  # disable
 urls_views["template-workflow-link"] = None
 urls_views["template-workflow-unlink"] = None
-
-router.register("workflows", WorkflowViewSet, basename="workflow")
-urls_views["workflow-list"] = WorkflowViewSet.as_view(
+urls_views["template-workflow-list"] = WorkflowViewSet.as_view(
     {"get": "list"}
 )  # list only
+
+router.register("workflows", WorkflowViewSet, basename="workflow")
 
 requests = router.register("requests", RequestViewSet, basename="request")
 requests.register(

--- a/pinakes/main/approval/views.py
+++ b/pinakes/main/approval/views.py
@@ -26,7 +26,6 @@ from pinakes.main.models import Tenant
 from pinakes.main.approval.models import (
     NotificationType,
     NotificationSetting,
-    Template,
     Workflow,
     Request,
 )
@@ -229,14 +228,7 @@ class WorkflowFilterBackend(BaseFilterBackend):
         ],
     ),
     create=extend_schema(
-        tags=(
-            "workflows",
-            "templates",
-        ),
-        description=(
-            "Create a workflow from a template identified by its id, available"
-            " to admin only"
-        ),
+        description="Create a workflow, available to admin only",
     ),
     partial_update=extend_schema(
         description=(
@@ -334,7 +326,6 @@ class WorkflowViewSet(
                 max_obj.internal_sequence.to_integral_value() + 1
             )
         serializer.save(
-            template=Template(id=self.kwargs["template_id"]),
             internal_sequence=next_seq,
             tenant=Tenant.current(),
         )


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2956

To create a new workflow now use `/workflows` instead of `/templates/{template_id}/workflows`. The body now accepts `"template": {id}`. This allows the user later to change template id.