### PR TITLE
Revisit flake8 configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,12 +16,8 @@ warnerrors = True
 
 [flake8]
 show-source = True
-# E123, E125 skipped as they are invalid PEP-8.
-# Non-PEP8 compilant errors:
-#  - E123: Closing bracket does not match indentation of opening bracket's line
-#  - E125: Continuation line with same indent as next logical line
-#  - W503: Line break before binary operator
-# Temporarily disabled:
-#  - E501: Line too long
-ignore = E123,E125,W503
+# Flake8 default ignore list:
+# ['W504', 'B904', 'B901', 'E24', 'W503', 'B950', 'E123', 'E704', 'B903', 'E121', 'B902', 'E226', 'E126']
+extend-ignore =
+    E203,  # Whitespace before ':' (false positive in slices, handled by black. see: https://github.com/psf/black/issues/315)
 exclude = .git,.tox


### PR DESCRIPTION
* Use `extend-ignore` for project ignore list, to keep default flake8
  ingnore list.
* Ignore `E203: Whitespace before ':'`, because it conflicts with black.
* Remove `E123` and `W503`, because they ignored by default.
* Remove `E125`, because it should be handled by black and there is no
  false positive in the codebase triggering this error. Therefore no
  reason for keeping it in the ignore list for now.