### PR TITLE
Refactor error handling in keycloak client

### DIFF
--- a/pinakes/common/auth/keycloak/client.py
+++ b/pinakes/common/auth/keycloak/client.py
@@ -70,17 +70,6 @@ class ApiClient:
         ).json()
 
     def exception_handler(self, e: requests.HTTPError):
-        status_code = e.response.status_code
-
-        # TODO(cutwater): Refactor this as a dispatch dictionary
-        exception_cls = exceptions.ApiException
-        if e.response.status_code == requests.codes.not_found:
-            exception_cls = exceptions.ResourceNotFound
-        elif e.response.status_code == requests.codes.conflict:
-            exception_cls = exceptions.ResourceExists
-        elif e.response.status_code == requests.codes.forbidden:
-            exception_cls = exceptions.Forbidden
-
         error = None
         error_description = None
         try:
@@ -92,4 +81,6 @@ class ApiClient:
                 error = data.get("error")
                 error_description = data.get("error_description")
 
+        status_code = e.response.status_code
+        exception_cls = exceptions.get_http_exception_class(status_code)
         raise exception_cls(error, error_description, status_code) from e

--- a/pinakes/common/auth/keycloak/exceptions.py
+++ b/pinakes/common/auth/keycloak/exceptions.py
@@ -1,11 +1,30 @@
+"""Keycloak client exception classes.
+
+Exception hierarchy:
+
+* KeycloakError
+  * HttpError
+    * Unauthorized
+    * Forbidden
+    * NotFound
+    * Conflict
+  * ClientError
+    * NoResultFound
+    * MultipleResultsFound
+"""
+import requests
 from typing import Optional
 
 
 class KeycloakError(Exception):
+    """Base class for all keycloak exceptions."""
+
     pass
 
 
-class ApiException(KeycloakError):
+class HttpError(KeycloakError):
+    """Base class for HTTP exceptions."""
+
     def __init__(
         self,
         error: Optional[str] = None,
@@ -27,15 +46,27 @@ class ApiException(KeycloakError):
         return result
 
 
-class ResourceNotFound(ApiException):
+class Unauthorized(HttpError):
+    """HTTP 401 Unauthorized"""
+
     pass
 
 
-class ResourceExists(ApiException):
+class Forbidden(HttpError):
+    """HTTP 403 Forbidden"""
+
     pass
 
 
-class Forbidden(ApiException):
+class NotFound(HttpError):
+    """HTTP 404 Not Found"""
+
+    pass
+
+
+class Conflict(HttpError):
+    """HTTP 409 Conflict"""
+
     pass
 
 
@@ -47,5 +78,18 @@ class NoResultFound(ClientError):
     pass
 
 
-class MultipleResourcesFound(ClientError):
+class MultipleResultsFound(ClientError):
     pass
+
+
+HTTP_EXCEPTIONS = {
+    requests.codes.unauthorized: Unauthorized,
+    requests.codes.forbidden: Forbidden,
+    requests.codes.not_found: NotFound,
+    requests.codes.conflict: Conflict,
+}
+
+
+def get_http_exception_class(status_code: int):
+    """Return exception class for HTTP response status code."""
+    return HTTP_EXCEPTIONS.get(status_code, HttpError)

--- a/pinakes/common/auth/keycloak/tests/unit/test_client.py
+++ b/pinakes/common/auth/keycloak/tests/unit/test_client.py
@@ -147,7 +147,7 @@ def test_api_client_exception_not_found(session):
     session.request.return_value = _mock_response_with_exception(
         status_code=requests.codes.not_found, json_data={}
     )
-    with pytest.raises(exceptions.ResourceNotFound) as excinfo:
+    with pytest.raises(exceptions.NotFound) as excinfo:
         client.request_json("GET", "https://example-6.com")
     assert str(excinfo.value) == "API Error (status: 404)"
 
@@ -157,7 +157,7 @@ def test_api_client_exception_conflict(session):
     session.request.return_value = _mock_response_with_exception(
         status_code=requests.codes.conflict, json_data={}
     )
-    with pytest.raises(exceptions.ResourceExists) as excinfo:
+    with pytest.raises(exceptions.Conflict) as excinfo:
         client.request_json("GET", "https://example-7.com")
     assert str(excinfo.value) == "API Error (status: 409)"
 
@@ -168,7 +168,7 @@ def test_api_client_exception_with_error(session):
         status_code=requests.codes.bad_request,
         json_data={"error": "invalid request"},
     )
-    with pytest.raises(exceptions.ApiException) as excinfo:
+    with pytest.raises(exceptions.HttpError) as excinfo:
         client.request_json("GET", "https://example-8.com")
     assert str(excinfo.value) == "invalid request (status: 400)"
 
@@ -182,6 +182,6 @@ def test_api_client_exception_with_error_description(session):
             "error_description": "unknown error",
         },
     )
-    with pytest.raises(exceptions.ApiException) as excinfo:
+    with pytest.raises(exceptions.HttpError) as excinfo:
         client.request_json("GET", "https://example-9.com")
     assert str(excinfo.value) == "invalid request: unknown error (status: 400)"

--- a/pinakes/common/auth/keycloak/tests/unit/test_uma_client.py
+++ b/pinakes/common/auth/keycloak/tests/unit/test_uma_client.py
@@ -286,7 +286,7 @@ def test_get_permission_by_name_multiple_results(
 ):
     api_client.request_json.return_value = [{}, {}]
 
-    with pytest.raises(exceptions.MultipleResourcesFound):
+    with pytest.raises(exceptions.MultipleResultsFound):
         uma_client.get_permission_by_name("permission01")
 
 

--- a/pinakes/common/auth/keycloak/uma.py
+++ b/pinakes/common/auth/keycloak/uma.py
@@ -103,7 +103,7 @@ class UmaClient:
         if not permissions:
             raise exceptions.NoResultFound
         if len(permissions) > 1:
-            raise exceptions.MultipleResourcesFound
+            raise exceptions.MultipleResultsFound
         return permissions[0]
 
     def find_permissions_by_name(


### PR DESCRIPTION
* Add docstrings.
* Rename `ApiException` to `HttpError` class.
* Consistent naming for `NoResultFound` and `MultipleResultsFound`
  exceptions.
* Use dispatch dictionary to return a concrete `HttpError` child class.