### PR TITLE
[SSP-2946] Exception handler for Keycloak Unauthorized

### DIFF
--- a/pinakes/common/exception_handler.py
+++ b/pinakes/common/exception_handler.py
@@ -1,29 +1,40 @@
-"""default exception handler for all uncaught exceptions"""
+"""Default exception handler for all uncaught exceptions."""
+import logging
+from typing import Optional, Any, Dict
+
+from django.contrib import auth
 from django.db import IntegrityError
 from django.utils.translation import gettext_lazy as _
 from rest_framework.views import exception_handler, set_rollback
 from rest_framework.response import Response
 from rest_framework import status
 
-import logging
+from pinakes.common.auth.keycloak import exceptions as keycloak_exc
 
 logger = logging.getLogger("django.request")
 
 
-def custom_exception_handler(exc, context):
+def custom_exception_handler(
+    exc: Exception, context: Dict[str, Any]
+) -> Optional[Response]:
     response = exception_handler(exc, context)
     if response is not None:
         return response
 
     # For all unhandled exceptions.
-    set_rollback()
     logger.exception("Caught an internal exception:")
 
     message = _("Internal Error")
-    code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     if isinstance(exc, IntegrityError):
         message = _(
             "{}. Report to the support team if it is not an user error."
         ).format(exc)
-        code = status.HTTP_400_BAD_REQUEST
-    return Response({"detail": message}, code)
+        status_code = status.HTTP_400_BAD_REQUEST
+    elif isinstance(exc, keycloak_exc.Unauthorized):
+        auth.logout(context["request"])
+        status_code = status.HTTP_403_FORBIDDEN
+        message = _("Unauthorized")
+
+    set_rollback()
+    return Response(data={"detail": message}, status=status_code)


### PR DESCRIPTION
Return 403 status code when backend uses expired access token
to access Keycloak.

https://issues.redhat.com/browse/SSP-2946