### PR TITLE
[SSP-2981] Last refresh messages was not reporting on survey updates

### DIFF
--- a/pinakes/main/inventory/serializers.py
+++ b/pinakes/main/inventory/serializers.py
@@ -62,6 +62,7 @@ class SourceSerializer(serializers.ModelSerializer):
         sii_stats = obj.last_refresh_stats.get("service_inventory", {})
         soi_stats = obj.last_refresh_stats.get("service_offering", {})
         son_stats = obj.last_refresh_stats.get("service_offering_node", {})
+        sp_stats = obj.last_refresh_stats.get("service_plan", {})
 
         filtered_sii_stats = {
             _(key): value for key, value in sii_stats.items() if value > 0
@@ -73,6 +74,9 @@ class SourceSerializer(serializers.ModelSerializer):
             _(key): value for key, value in son_stats.items() if value > 0
         }
 
+        filtered_sp_stats = {
+            _(key): value for key, value in sp_stats.items() if value > 0
+        }
         obj.last_refresh_message = ""
         if bool(filtered_sii_stats):
             obj.last_refresh_message = _(
@@ -88,6 +92,11 @@ class SourceSerializer(serializers.ModelSerializer):
             obj.last_refresh_message += _(
                 "Workflow Template Nodes: %(son_stats)s;\n"
             ) % {"son_stats": filtered_son_stats}
+
+        if bool(filtered_sp_stats):
+            obj.last_refresh_message += _("Service Plan: %(sp_stats)s;\n") % {
+                "sp_stats": filtered_sp_stats
+            }
 
         if not obj.last_refresh_message:
             obj.last_refresh_message = _("Nothing to update")

--- a/pinakes/main/inventory/task_utils/refresh_inventory.py
+++ b/pinakes/main/inventory/task_utils/refresh_inventory.py
@@ -80,6 +80,9 @@ class RefreshInventory:
             self.source.last_refresh_stats[
                 "service_offering_node"
             ] = son.get_stats()
+            self.source.last_refresh_stats[
+                "service_plan"
+            ] = plan_importer.get_stats()
 
             self.source.last_successful_refresh_at = timezone.now()
             self.source.refresh_state = Source.State.DONE

--- a/pinakes/main/inventory/tests/functional/test_source_endpoints.py
+++ b/pinakes/main/inventory/tests/functional/test_source_endpoints.py
@@ -28,12 +28,55 @@ def test_source_list(api_request):
 def test_source_retrieve(api_request):
     """Test to retrieve Source endpoint"""
 
-    source = SourceFactory()
+    last_refresh_stats = {
+        "service_inventory": {"adds": 1, "updates": 1, "deletes": 0},
+        "service_offering": {"adds": 2, "delates": 0},
+        "service_offering_node": {"adds": 3},
+        "service_plan": {"adds": 2, "updates": 0},
+    }
+    source = SourceFactory(
+        availability_status="available", last_refresh_stats=last_refresh_stats
+    )
     response = api_request("get", "inventory:source-detail", source.id)
 
     assert response.status_code == 200
     content = json.loads(response.content)
     assert content["id"] == source.id
+
+
+@pytest.mark.django_db
+def test_source_nothing_to_update(api_request):
+    """Test to retrieve Source endpoint with no updates"""
+
+    last_refresh_stats = {
+        "service_inventory": {"adds": 0, "updates": 0, "deletes": 0},
+        "service_offering": {"adds": 0, "delates": 0},
+        "service_offering_node": {"adds": 0},
+        "service_plan": {"adds": 0, "updates": 0},
+    }
+    source = SourceFactory(
+        availability_status="available", last_refresh_stats=last_refresh_stats
+    )
+    response = api_request("get", "inventory:source-detail", source.id)
+
+    assert response.status_code == 200
+    content = json.loads(response.content)
+    assert content["id"] == source.id
+    assert content["last_refresh_message"] == "Nothing to update"
+
+
+@pytest.mark.django_db
+def test_source_failed_state(api_request):
+    """Test to retrieve Source endpoint in a failed state"""
+    source = SourceFactory(
+        availability_status="available", refresh_state=Source.State.FAILED
+    )
+    response = api_request("get", "inventory:source-detail", source.id)
+
+    assert response.status_code == 200
+    content = json.loads(response.content)
+    assert content["id"] == source.id
+    assert "Refresh failed" in content["last_refresh_message"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The refresh message was missing the service plan counters
https://issues.redhat.com/browse/SSP-2981

Before
<img width="593" alt="Screen Shot 2022-06-07 at 2 20 40 PM" src="https://user-images.githubusercontent.com/6452699/172468068-30574230-7c2f-47ae-99ca-2be9cf71b2a6.png">


After
<img width="592" alt="Screen Shot 2022-06-07 at 2 30 41 PM" src="https://user-images.githubusercontent.com/6452699/172468100-c810ab3b-6b04-4d48-8a18-21a81e56447a.png">


