### PR TITLE
[SSP-2984] Fix empty notified_at even when request has finished_at

### DIFF
--- a/pinakes/main/analytics/analytics_collectors.py
+++ b/pinakes/main/analytics/analytics_collectors.py
@@ -807,14 +807,14 @@ def approval_request_time_spent_by_groups(since, **kwargs):
             time_spent_intervals = {}
 
             for request in request_list:
+                started_at = request["notified_at"] or request["created_at"]
+
                 if request["finished_at"]:
                     time_spent_intervals[request["id"]] = (
-                        request["finished_at"] - request["notified_at"]
+                        request["finished_at"] - started_at
                     )
                 else:  # request is waiting for processing
-                    time_spent_intervals[request["id"]] = (
-                        now() - request["notified_at"]
-                    )
+                    time_spent_intervals[request["id"]] = now() - started_at
                 request["time_spent_in_approval"] = time_spent_intervals[
                     request["id"]
                 ].total_seconds()

--- a/pinakes/main/analytics/tests/test_analytics_collectors.py
+++ b/pinakes/main/analytics/tests/test_analytics_collectors.py
@@ -739,3 +739,29 @@ def test_order_data_by_product_collector(sqlite_copy_expert):
     assert [*results.keys()] == [product_1.id, product_2.id]
     assert len(results[product_1.id]["completed_orders"]) == 1
     assert len(results[product_2.id]["failed_orders"]) == 1
+
+
+@pytest.mark.django_db
+def test_approval_request_time_spent_by_groups(sqlite_copy_expert):
+    time_start = now() - timedelta(hours=2)
+
+    group_1 = GroupFactory()
+    group_2 = GroupFactory()
+    RequestFactory(group_name=group_1.name, group_ref=group_1.id)
+    RequestFactory(
+        group_name=group_1.name,
+        group_ref=group_1.id,
+        notified_at=(now() - timedelta(hours=1)),
+    )
+    RequestFactory(
+        group_name=group_2.name,
+        group_ref=group_2.id,
+        finished_at=(now() + timedelta(hours=2)),
+    )
+
+    results = collectors.approval_request_time_spent_by_groups(
+        time_start, until=now() + timedelta(seconds=1)
+    )
+
+    assert len(results) == 2
+    assert [*results.keys()] == [group_1.name, group_2.name]


### PR DESCRIPTION
Approval request may have no `notified_at` timestamp, even when it already finished. Fix analytic collector to use `created_at` for this case.

https://issues.redhat.com/browse/SSP-2984