### PR TITLE
[SSP-3002] Remove extra actions from the orders/:id endpoint

### DIFF
--- a/pinakes/main/catalog/tests/functional/test_order_end_points.py
+++ b/pinakes/main/catalog/tests/functional/test_order_end_points.py
@@ -106,19 +106,6 @@ def test_order_retrieve_extra(api_request, mocker):
 
 
 @pytest.mark.django_db
-def test_order_delete(api_request, mocker):
-    """Delete a single order by id"""
-    check_object_permission = mocker.spy(
-        OrderPermission, "perform_check_object_permission"
-    )
-    order = OrderFactory()
-    response = api_request("delete", "catalog:order-detail", order.id)
-
-    assert response.status_code == 204
-    check_object_permission.assert_called()
-
-
-@pytest.mark.django_db
 def test_order_submit(api_request, mocker):
     """Submit a single order by id"""
     mocker.patch("django_rq.enqueue")
@@ -228,6 +215,15 @@ def test_order_cancel_with_uncancelable_states(api_request, mocker):
         "Order {} is not cancel able in its current state: {}"
     ).format(order.id, order.state)
     check_object_permission.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_order_delete_not_supported(api_request, mocker):
+    """Delete a single order by id"""
+    order = OrderFactory()
+    response = api_request("delete", "catalog:order-detail", order.id)
+
+    assert response.status_code == 405
 
 
 @pytest.mark.django_db

--- a/pinakes/main/catalog/urls.py
+++ b/pinakes/main/catalog/urls.py
@@ -61,6 +61,8 @@ orders.register(
     basename="order-orderitem",
     parents_query_lookups=OrderItemViewSet.parent_field_names,
 )
+urls_views["order-detail"] = OrderViewSet.as_view({"get": "retrieve"})
+
 orders.register(
     r"approval_requests",
     ApprovalRequestViewSet,


### PR DESCRIPTION
Remove `delete` and `patch` actions from the endpoint of `orders/:id`

https://issues.redhat.com/browse/SSP-3002