### PR TITLE
[SSP-2818] Bearer token authentication

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -83,16 +83,8 @@ def api_request(admin):
         )
         request.session = mock.Mock()
         if user and authenticated:
-            force_authenticate(request, user=user)
-
-        access_token = jwt.encode(DUMMY_ACCESS_TOKEN, "", algorithm="none")
-        keycloak_mock = mock.Mock()
-        keycloak_mock.extra_data = {
-            "id": "1",
-            "access_token": access_token,
-            "refresh_token": access_token,
-        }
-        request.keycloak_user = keycloak_mock
+            access_token = jwt.encode(DUMMY_ACCESS_TOKEN, "", algorithm="none")
+            force_authenticate(request, user=user, token=access_token)
 
         if rbac_enabled:
             authz_client_mock = contextlib.nullcontext()

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,0 +1,120 @@
+# Authentication
+
+The Pinakes project supports two authentication schemas:
+  - Session authentication. Used for browser clients.
+  - Bearer authentication. Used for standalone clients (e.g. CLI applications).
+
+## Bearer authentication
+
+To use Bearer authentication, client must first obtain access token from Keycloak directly.
+Typically, a separate Keycloak client is required.
+
+A standalone CLI application should create a public client and use
+[OAuth 2.0 Device Authorization Grant](https://oauth.net/2/device-flow/) flow
+to authenticate on Keycloak and receive tokens.
+
+### Device flow
+
+The [OAuth 2.0 Device Authorization Grant](https://oauth.net/2/device-flow/) 
+(formerly known as the Device Flow) is intended for clients that have no browser or limited input 
+capability to obtain an access token.
+
+Keycloak supports the Device Flow for both public and confidential clients.
+This chapter describes the Device Flow for a public client using an example of a CLI application.
+
+To obtain a token using device flow, a standalone client must request a device code first:
+
+```shell
+$ CLIENT_ID=pinakes-cli
+$ curl -X POST -d "client_id=$CLIENT_ID" \
+  "http://localhost:8080/auth/realms/pinakes/protocol/openid-connect/auth/device" | jq
+{
+  "device_code": "<DEVICE_CODE>",
+  "user_code": "JGVH-ZKBG",
+  "verification_uri": "http://localhost:8080/auth/realms/pinakes/device",
+  "verification_uri_complete": "http://localhost:8080/auth/realms/pinakes/device?user_code=JGVH-ZKBG",
+  "expires_in": 600,
+  "interval": 5
+}
+```
+
+Then user should open the verification URL (`http://localhost:8080/auth/realms/pinakes/device`)
+in their browser and enter the `user_code` value (`JGVH-ZKBG`), returned by previous request.
+
+After user authentication and code verification is complete, standalone client may request
+tokens by using the `device_code` received at previous step:
+
+```shell
+$ curl -X POST -d "grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+    -d "client_id=$CLIENT_ID" -d "device_code=<DEVICE_CODE>" \
+    "http://localhost:8080/auth/realms/pinakes/protocol/openid-connect/token"
+{
+    "access_token": "eyJhb...",
+    "expires_in": 300,
+    "refresh_expires_in": 1800,
+    "refresh_token": "05OD...",
+    "token_type": "Bearer",
+    "not-before-policy": 0,
+    "session_state": "c708...",
+    "scope": "profile email"
+}  
+```
+
+### Audience configuration
+
+Pinakes verifies audience of presented access token. This may require additional configuration
+of a client or realm.
+
+See [Keycloak: Audience Support](https://www.keycloak.org/docs/latest/server_admin/#audience-support)
+for more details.
+
+### Development environment
+
+For debugging purposes the development environment you need to create a confidential 
+Keycloak client with `Direct Access Grants Enabled` option enabled, which
+allows usage of [OAuth 2.0 Password Grant](https://oauth.net/2/grant-types/password/).
+
+_**Warning:** The Password Grant flow is deprecated and discouraged.
+You should not use it in production._ 
+
+Examples below use client named `pinakes-cli`. 
+
+**Example:**
+
+```shell
+$ CLIENT_ID=pinakes-cli
+$ ACCESS_TOKEN="$(curl -sS http://localhost:8080/auth/realms/pinakes/protocol/openid-connect/token \
+    -d scope=openid -d grant_type=password -d client_id=$CLIENT_ID \
+    -d username=fred.sample -d password=fred | jq -r .access_token)"
+```
+
+You can debug token payload:
+
+```shell
+echo $ACCESS_TOKEN | cut -d. -f2 | tr '+/' '-_' | base64 -d 2>/dev/null | jq
+{
+  "exp": 1656070300,
+  "iat": 1656070000,
+  "jti": "f715b6aa-062a-47fc-8c45-81460806040d",
+  ...
+}
+```
+
+After you received an access token, you can use it to access the API:
+
+```shell
+curl -sS -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:8000/api/pinakes/auth/me/
+```
+
+### Authentication backends
+
+Pinakes provides two authentication backend classes, that implement Bearer authentication and
+verify access tokens, issued by Keycloak:
+
+- `KeycloakBearerOfflineAuthentication`. Performs an offline authentication, by verifying access
+  token digital signature. Enabled by default.
+- `KeycloakBearerOnlineuthentication`. Verifies access token by calling Keycloak 
+  token introspection endpoint.
+
+These backends are mutually exclusive. At the moment it is not possible to switch between backends
+by using environment variable settings.

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -113,7 +113,7 @@ verify access tokens, issued by Keycloak:
 
 - `KeycloakBearerOfflineAuthentication`. Performs an offline authentication, by verifying access
   token digital signature. Enabled by default.
-- `KeycloakBearerOnlineuthentication`. Verifies access token by calling Keycloak 
+- `KeycloakBearerOnlineAuthentication`. Verifies access token by calling Keycloak 
   token introspection endpoint.
 
 These backends are mutually exclusive. At the moment it is not possible to switch between backends

--- a/pinakes/common/auth/keycloak_django/authentication.py
+++ b/pinakes/common/auth/keycloak_django/authentication.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AbstractUser
+from django.utils.translation import gettext_lazy as _
+from jose import jwt
+from rest_framework import authentication
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.request import Request
+from social_django.models import AbstractUserSocialAuth, DjangoStorage
+from social_django.strategy import DjangoStrategy
+
+from pinakes.common.auth.keycloak_oidc import KeycloakOpenIdConnect
+
+User: AbstractUser = get_user_model()
+UserTokenPair = Tuple[AbstractUser, str]
+
+
+class _CustomDjangoStrategy(DjangoStrategy):
+    def __init__(self, settings, storage, request=None, tpl=None):
+        self._settings = settings
+        super().__init__(storage, request, tpl)
+
+    def get_setting(self, name):
+        if name in self._settings:
+            return self._settings[name]
+        return super().get_setting(name)
+
+
+class KeycloakSessionAuthentication(authentication.SessionAuthentication):
+    auth_backend = KeycloakOpenIdConnect
+
+    def authenticate(self, request: Request) -> Optional[UserTokenPair]:
+        auth = super().authenticate(request)
+        if auth is None:
+            return None
+        user = auth[0]
+        return user, request.keycloak_user.access_token
+
+    def get_social_user(
+        self, request: Request
+    ) -> Optional[AbstractUserSocialAuth]:
+        return request.keycloak_user
+
+
+class BaseKeycloakBearerAuthentication(authentication.BaseAuthentication):
+    auth_scheme = "Bearer"
+    auth_backend = KeycloakOpenIdConnect
+    # NOTE: Use custom pipeline to disable loading extra data
+    auth_pipeline = [
+        "social_core.pipeline.social_auth.social_details",
+        "social_core.pipeline.social_auth.social_uid",
+        "social_core.pipeline.social_auth.auth_allowed",
+        "social_core.pipeline.social_auth.social_user",
+        "social_core.pipeline.user.get_username",
+        "social_core.pipeline.user.create_user",
+        "social_core.pipeline.social_auth.associate_user",
+        "social_core.pipeline.user.user_details",
+    ]
+
+    def authenticate_header(self, request: Request) -> str:
+        return self.auth_scheme
+
+    def get_token(self, request: Request):
+        auth_header = request.headers.get("Authorization")
+        if not auth_header:
+            return None
+
+        auth = auth_header.split()
+        if not auth or auth[0].lower() != self.auth_scheme.lower():
+            return None
+
+        if len(auth) == 1:
+            msg = _("Invalid authorization header. No credentials provided.")
+            raise AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = _(
+                "Invalid authorization header. Credentials string should "
+                "not contain spaces."
+            )
+            raise AuthenticationFailed(msg)
+        return auth[1]
+
+    def load_strategy(self, request: Request) -> DjangoStrategy:
+        settings = {
+            "SOCIAL_AUTH_PIPELINE": self.auth_pipeline,
+        }
+        strategy = _CustomDjangoStrategy(
+            settings, DjangoStorage, request=request
+        )
+        return strategy
+
+
+class KeycloakBearerOfflineAuthentication(BaseKeycloakBearerAuthentication):
+    def authenticate(self, request: Request) -> Optional[UserTokenPair]:
+        token = self.get_token(request)
+        if token is None:
+            return None
+
+        strategy = self.load_strategy(request)
+        backend = self.auth_backend(strategy)
+
+        key = backend.find_valid_key(token)
+        if not key:
+            raise AuthenticationFailed(_("No valid JWK found."))
+
+        client_id, _client_secret = backend.get_key_and_secret()
+        try:
+            payload = jwt.decode(
+                token,
+                key,
+                algorithms=backend.JWT_ALGORITHMS,
+                audience=client_id,
+                issuer=backend.id_token_issuer(),
+            )
+        except jwt.ExpiredSignatureError:
+            raise AuthenticationFailed(_("Signature has expired."))
+        except jwt.JWTClaimsError:
+            raise AuthenticationFailed(_("Invalid claims."))
+        except jwt.JWTError:
+            raise AuthenticationFailed(_("Invalid signature."))
+
+        user = strategy.authenticate(backend, response=payload)
+        if not user:
+            raise AuthenticationFailed
+        return user, token
+
+
+class KeycloakBearerOnlineAuthentication(BaseKeycloakBearerAuthentication):
+    def authenticate(self, request: Request) -> Optional[UserTokenPair]:
+        token = self.get_token(request)
+        if token is None:
+            return None
+
+        strategy = self.load_strategy(request)
+        backend = self.auth_backend(strategy)
+
+        client_id, client_secret = backend.get_key_and_secret()
+
+        introspect_url = self._introspect_url(backend)
+        response = backend.get_json(
+            introspect_url,
+            method="POST",
+            auth=(client_id, client_secret),
+            data={"token": token},
+        )
+
+        self._validate_response(response, client_id)
+
+        response = backend.user_data(token)
+        user = strategy.authenticate(backend, response=response)
+        if not user:
+            raise AuthenticationFailed
+        return user, token
+
+    def _introspect_url(self, backend: KeycloakOpenIdConnect):
+        return backend.oidc_config().get("introspection_endpoint")
+
+    def _validate_response(self, response, client_id):
+        if not response.get("active"):
+            raise AuthenticationFailed(_("Token expired"))
+
+        # Validate audience
+        audience_claims = response.get("audience")
+        if not audience_claims:
+            raise AuthenticationFailed(_("Invalid audience"))
+        if isinstance(audience_claims, str):
+            audience_claims = [audience_claims]
+        if client_id not in audience_claims:
+            raise AuthenticationFailed(_("Invalid audience"))

--- a/pinakes/common/auth/keycloak_django/permissions.py
+++ b/pinakes/common/auth/keycloak_django/permissions.py
@@ -226,7 +226,7 @@ def check_wildcard_permission(
 ) -> bool:
     scope = make_scope_name(resource_type, permission)
     resource = make_resource_name(resource_type, WILDCARD_RESOURCE_ID)
-    client = get_authz_client(request.keycloak_user.access_token)
+    client = get_authz_client(request.auth)
     return client.check_permissions(
         keycloak_models.AuthzPermission(
             resource=resource,
@@ -250,7 +250,7 @@ def check_resource_permission(
         resource=resource_name,
         scope=scope,
     )
-    client = get_authz_client(request.keycloak_user.access_token)
+    client = get_authz_client(request.auth)
     return client.check_permissions([wildcard_permission, object_permission])
 
 
@@ -278,7 +278,7 @@ class PermittedResourcesResult:
 def get_permitted_resources(
     resource_type: str, permission: str, request: Request
 ) -> PermittedResourcesResult:
-    client = get_authz_client(request.keycloak_user.access_token)
+    client = get_authz_client(request.auth)
     permissions = client.get_permissions(
         keycloak_models.AuthzPermission(
             scope=make_scope_name(resource_type, permission)

--- a/pinakes/common/auth/keycloak_django/test_authentication_backends.py
+++ b/pinakes/common/auth/keycloak_django/test_authentication_backends.py
@@ -1,0 +1,203 @@
+from unittest import mock
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AbstractUser
+from jose import jwt
+from rest_framework import status
+from rest_framework.test import APIClient
+from rest_framework.views import APIView
+
+from pinakes.common.auth.keycloak_django.authentication import (
+    KeycloakSessionAuthentication,
+    KeycloakBearerOfflineAuthentication,
+    KeycloakBearerOnlineAuthentication,
+)
+from pinakes.common.auth.keycloak_oidc import KeycloakOpenIdConnect
+
+User: AbstractUser = get_user_model()
+
+USER_UID = "e993c33a-640f-45e4-8aff-21eed3b2781c"
+TOKEN_KEY = "secret"
+TOKEN_ISSUER = "https://keycloak.example.com/auth/realms/test"
+REFRESH_TOKEN = "DUMMY.REFRESH.TOKEN"
+ACCESS_TOKEN = jwt.encode(
+    {
+        "sub": USER_UID,
+        "name": "Fred Sample",
+        "preferred_username": "fred",
+        "aud": ["account", "pinakes"],
+        "iss": TOKEN_ISSUER,
+    },
+    key=TOKEN_KEY,
+)
+
+
+# NOTE(cutwater): Because some of rest framework settings
+#  (i.e. AUTHENTICATION_BACKENDS) are evaluated at module load time,
+#  it is not possible to use Django's `@override_settings` decorator.
+#  APIView class is patched directly instead.
+
+
+@pytest.fixture
+def testuser():
+    user = User.objects.create_user(username="fred")
+    user.social_auth.create(
+        provider=KeycloakOpenIdConnect.name,
+        uid=USER_UID,
+        extra_data={
+            "access_token": ACCESS_TOKEN,
+            "refresh_token": REFRESH_TOKEN,
+        },
+    )
+    user.backend = KeycloakOpenIdConnect
+    return user
+
+
+@pytest.mark.django_db
+def test_session_auth(mocker, testuser):
+    mocker.patch.object(
+        APIView, "authentication_classes", [KeycloakSessionAuthentication]
+    )
+    authenticate = mocker.spy(KeycloakSessionAuthentication, "authenticate")
+
+    client = APIClient()
+    client.force_login(testuser)
+
+    response = client.get("/api/pinakes/auth/me/")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert authenticate.call_count == 1
+    assert authenticate.spy_return == (testuser, ACCESS_TOKEN)
+
+
+@pytest.mark.django_db
+def test_bearer_offline_auth_new_user(mocker):
+    authenticate = mocker.spy(
+        KeycloakBearerOfflineAuthentication, "authenticate"
+    )
+    mocker.patch.object(
+        APIView,
+        "authentication_classes",
+        [KeycloakBearerOfflineAuthentication],
+    )
+    mocker.patch.multiple(
+        KeycloakOpenIdConnect,
+        find_valid_key=mock.Mock(return_value=TOKEN_KEY),
+        oidc_config=mock.Mock(
+            return_value={
+                "issuer": TOKEN_ISSUER,
+            }
+        ),
+        JWT_ALGORITHMS=["HS256"],
+    )
+
+    user_exists = User.objects.filter(username="fred").exists()
+    assert not user_exists
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION="Bearer " + ACCESS_TOKEN)
+
+    response = client.get("/api/pinakes/auth/me/")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    try:
+        user = User.objects.get(username="fred")
+    except User.DoesNotExist:
+        pytest.fail("User wasn't created.")
+
+    social_user = user.social_auth.get(provider="keycloak-oidc")
+    assert social_user.extra_data == {}
+
+    assert authenticate.call_count == 1
+    assert authenticate.spy_return == (user, ACCESS_TOKEN)
+
+
+@pytest.mark.django_db
+def test_bearer_offline_auth_existing_user(mocker, testuser):
+    authenticate = mocker.spy(
+        KeycloakBearerOfflineAuthentication, "authenticate"
+    )
+    mocker.patch.object(
+        APIView,
+        "authentication_classes",
+        [KeycloakBearerOfflineAuthentication],
+    )
+    mocker.patch.multiple(
+        KeycloakOpenIdConnect,
+        find_valid_key=mock.Mock(return_value=TOKEN_KEY),
+        oidc_config=mock.Mock(
+            return_value={
+                "issuer": TOKEN_ISSUER,
+            }
+        ),
+        JWT_ALGORITHMS=["HS256"],
+    )
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION="Bearer " + ACCESS_TOKEN)
+
+    response = client.get("/api/pinakes/auth/me/")
+    assert response.status_code == status.HTTP_200_OK
+
+    social_user = testuser.social_auth.get(provider="keycloak-oidc")
+    assert social_user.extra_data == {
+        "access_token": ACCESS_TOKEN,
+        "refresh_token": REFRESH_TOKEN,
+    }
+
+    assert authenticate.call_count == 1
+    assert authenticate.spy_return == (testuser, ACCESS_TOKEN)
+
+
+@pytest.mark.django_db
+def test_bearer_online_auth(mocker, testuser):
+    authenticate = mocker.spy(
+        KeycloakBearerOnlineAuthentication, "authenticate"
+    )
+    mocker.patch.object(
+        APIView, "authentication_classes", [KeycloakBearerOnlineAuthentication]
+    )
+
+    def get_json(obj, url, **kwargs):
+        if url == "<introspect>":
+            return {
+                "active": True,
+                "audience": ["account", "pinakes"],
+            }
+        if url == "<userinfo>":
+            return {
+                "sub": USER_UID,
+                "name": "Fred Sample",
+                "preferred_username": "fred",
+            }
+        raise ValueError("Unexpected url")
+
+    mocker.patch.multiple(
+        KeycloakOpenIdConnect,
+        get_json=get_json,
+        oidc_config=mock.Mock(
+            return_value={
+                "introspection_endpoint": "<introspect>",
+                "userinfo_endpoint": "<userinfo>",
+            }
+        ),
+        JWT_ALGORITHMS=["HS256"],
+    )
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION="Bearer " + ACCESS_TOKEN)
+
+    response = client.get("/api/pinakes/auth/me/")
+    assert response.status_code == status.HTTP_200_OK
+
+    social_user = testuser.social_auth.get(provider="keycloak-oidc")
+    assert social_user.extra_data == {
+        "access_token": ACCESS_TOKEN,
+        "refresh_token": REFRESH_TOKEN,
+    }
+
+    assert authenticate.call_count == 1
+    assert authenticate.spy_return == (testuser, ACCESS_TOKEN)

--- a/pinakes/main/auth/serializers.py
+++ b/pinakes/main/auth/serializers.py
@@ -1,7 +1,7 @@
 """Serializer for auth object"""
 from rest_framework import serializers
 
-import jwt
+from jose import jwt
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -21,9 +21,9 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     def get_roles(self, _obj):
         """Get the current users roles from the request"""
         request = self.context.get("request")
-        extra_data = request.keycloak_user.extra_data
         jot = jwt.decode(
-            extra_data["access_token"],
+            request.auth,
+            "",
             options={"verify_signature": False, "verify_aud": False},
         )
         roles = (

--- a/pinakes/main/auth/tests/functional/test_session_logout.py
+++ b/pinakes/main/auth/tests/functional/test_session_logout.py
@@ -1,11 +1,65 @@
-"""Module to test session logout end point."""
+"""Test session logout endpoint."""
 import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AbstractUser
 from rest_framework import status
+from rest_framework.test import APIClient
+
+from pinakes.common.auth.keycloak_django.authentication import (
+    KeycloakBearerOfflineAuthentication,
+)
+from pinakes.common.auth.keycloak_oidc import KeycloakOpenIdConnect
+
+
+User: AbstractUser = get_user_model()
+
+ACCESS_TOKEN = "DUMMY.ACCESS.TOKEN"
+REFRESH_TOKEN = "DUMMY.REFRESH.TOKEN"
 
 
 @pytest.mark.django_db
-def test_session_logout(api_request, mocker):
+def test_session_logout(mocker, admin):
     """Logout an authenticated user from a single session"""
-    mocker.patch("pinakes.main.auth.views.get_oidc_client")
-    response = api_request("post", "auth:logout")
+    oidc_client = mocker.patch(
+        "pinakes.main.auth.views.get_oidc_client"
+    ).return_value
+
+    user = User.objects.create_user(username="test123", password="secret123")
+    user.social_auth.create(
+        provider=KeycloakOpenIdConnect.name,
+        extra_data={
+            "access_token": ACCESS_TOKEN,
+            "refresh_token": REFRESH_TOKEN,
+        },
+    )
+    user.backend = KeycloakOpenIdConnect
+
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post("/api/pinakes/auth/logout/")
+
     assert response.status_code == status.HTTP_204_NO_CONTENT
+    oidc_client.logout_user_session.assert_called_once_with(
+        ACCESS_TOKEN,
+        REFRESH_TOKEN,
+    )
+
+
+@pytest.mark.django_db
+def test_session_logout_bearer_auth(mocker, admin):
+    """Logout when using bearer authentication must fail."""
+    user = User.objects.create_user(username="test123", password="secret123")
+
+    mocker.patch.object(
+        KeycloakBearerOfflineAuthentication,
+        "authenticate",
+        return_value=(user, ACCESS_TOKEN),
+    )
+
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION="Bearer " + ACCESS_TOKEN)
+
+    response = client.post("/api/pinakes/auth/logout/")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/pinakes/settings/defaults.py
+++ b/pinakes/settings/defaults.py
@@ -129,7 +129,9 @@ REST_FRAMEWORK = {
     ),
     "PAGE_SIZE": 25,
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework.authentication.SessionAuthentication",
+        "pinakes.common.auth.keycloak_django.authentication.KeycloakSessionAuthentication",  # noqa
+        "pinakes.common.auth.keycloak_django.authentication.KeycloakBearerOfflineAuthentication",  # noqa
+        # "pinakes.common.auth.keycloak_django.authentication.KeycloakBearerOnlineAuthentication",  # noqa
     ),
     "DEFAULT_FILTER_BACKENDS": (
         "django_filters.rest_framework.DjangoFilterBackend",


### PR DESCRIPTION
* Add `KeycloakBearerOfflineAuthentication` authentication class.
  It implements offline access token validation, by verifying token
  signature. Enabled by default.
* Add `KeycloakBearerOnlineAuthentication` authentication class.
  It implements online access token authentication by calling Keycloak's
  `introspect` endpoint to validate token itself and `userinfo` endpoint
  to fetch user details.
* Add `KeycloakSessionAuthentication` class for an appropriate
  integration of middleware with DRF authentication infrastructure.

Implements: https://issues.redhat.com/browse/SSP-2818