### PR TITLE
Misc: Remove unused `restframework.authtoken` django app

### DIFF
--- a/pinakes/settings/defaults.py
+++ b/pinakes/settings/defaults.py
@@ -58,7 +58,6 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "rest_framework",
     "django_filters",
-    "rest_framework.authtoken",
     "taggit",
     "django_rq",
     "drf_spectacular",


### PR DESCRIPTION
The `restframework.authtoken` app is a part of the rest framework,
that is required for DRF built-in token authentication.
Since it is not used in the project, it can be removed.