### PR TITLE
Misc: Remove unused ModelBackend

### DIFF
--- a/pinakes/settings/defaults.py
+++ b/pinakes/settings/defaults.py
@@ -173,7 +173,6 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTHENTICATION_BACKENDS = [
     "pinakes.common.auth.keycloak_oidc.KeycloakOpenIdConnect",
-    "django.contrib.auth.backends.ModelBackend",
 ]
 
 # Internationalization


### PR DESCRIPTION
Pinakes uses only Keycloak authentication backend.
The `ModelBackend` enables username \ password authentication,
which is not used in the project.
It was only unappropriately used in the unit tests, which got
replaced in #562.