### PR TITLE
[SSP-3018] Add missing nullable for request_completed_at

### DIFF
--- a/pinakes/main/catalog/serializers.py
+++ b/pinakes/main/catalog/serializers.py
@@ -388,6 +388,9 @@ class ApprovalRequestSerializer(serializers.ModelSerializer):
             "request_completed_at",
             "state",
         )
+        extra_kwargs = {
+            "request_completed_at": {"allow_null": True},
+        }
 
     def get_state(self, obj):
         return _(obj.state)


### PR DESCRIPTION
Add the missing `nullable` for `request_completed_at` of approval request

https://issues.redhat.com/browse/SSP-3018