### PR TITLE
[SSP-3004] Select sub-requests belong to the same parent only

### DIFF
--- a/pinakes/main/approval/services/process_root_request.py
+++ b/pinakes/main/approval/services/process_root_request.py
@@ -84,7 +84,7 @@ class ProcessRootRequest:
         if self.request.is_parent():
             first_child = self.request.subrequests.order_by("id").first()
             first_leaves = Request.objects.filter(
-                workflow=first_child.workflow
+                workflow=first_child.workflow, parent=self.request
             )
 
         if len(first_leaves) == 1:


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-3004

Fixed the second issue reported in above issue. When we select sub-requests to start they must belong to the same parent. Otherwise older finished requests might be selected that result in the error `InvalidStateTransitionException`