### PR TITLE
[SSP-2819] New Keycloak client for Bearer auth

### DIFF
--- a/tools/keycloak_setup/collection/roles/setup/defaults/main.yml
+++ b/tools/keycloak_setup/collection/roles/setup/defaults/main.yml
@@ -17,3 +17,4 @@ web_origins:
 realm_management_roles:
   - view-users
 verify_keycloak_ssl: "{{ lookup('env', 'PINAKES_KEYCLOAK_VERIFY_SSL') | default('true', True) }}"
+create_cli_client: false

--- a/tools/keycloak_setup/collection/roles/setup/tasks/create_cli_client.yml
+++ b/tools/keycloak_setup/collection/roles/setup/tasks/create_cli_client.yml
@@ -1,0 +1,22 @@
+---
+- community.general.keycloak_client:
+    state: present
+    realm: "{{ realm_name }}"
+    name: "{{ client_name }}-cli"
+    client_id: "{{ client_name }}-cli"
+    protocol: openid-connect
+    enabled: true
+    description: "CLI client for Pinakes"
+    validate_certs: "{{ verify_keycloak_ssl }}"
+    admin_url: "{{ admin_url }}"
+    auth_client_id: "{{ auth_client_id }}"
+    auth_keycloak_url: "{{ auth_keycloak_url }}"
+    auth_password: "{{ auth_password }}"
+    auth_realm: "{{ auth_realm }}"
+    auth_username: "{{ auth_username }}"
+    direct_access_grants_enabled: true
+    public_client: true
+    redirect_uris: "{{ redirect_uris }}"
+    root_url: "{{ root_url }}"
+    standard_flow_enabled: true
+    web_origins: "{{ web_origins }}"

--- a/tools/keycloak_setup/collection/roles/setup/tasks/main.yml
+++ b/tools/keycloak_setup/collection/roles/setup/tasks/main.yml
@@ -72,3 +72,5 @@
     catalog_client: "{{ keycloak_clients['json'][0]  }}"
 - include_tasks: keycloak_seed.yml
   when: seed_keycloak
+- include_tasks: create_cli_client.yml
+  when: create_cli_client

--- a/tools/keycloak_setup/dev.yml
+++ b/tools/keycloak_setup/dev.yml
@@ -2,6 +2,7 @@
 - hosts: localhost
   vars:
     verify_keycloak_ssl: false
+    create_cli_client: true
     seed_keycloak: true
     seed_groups:
       - name: Information Technology - Sample

--- a/tools/keycloak_setup/qa.yml
+++ b/tools/keycloak_setup/qa.yml
@@ -2,6 +2,7 @@
 - hosts: localhost
   vars:
     verify_keycloak_ssl: false
+    create_cli_client: true
     seed_keycloak: true
     seed_groups:
       - name: catalog-admins


### PR DESCRIPTION
Add new keycloak client `pinakes-cli` for development environment
to issue standalone access tokens for external applications.

Issue: https://issues.redhat.com/browse/SSP-2819

Related: #562 