### PR TITLE
fix license filename

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ author-email = info@ansible.com
 summary = "Automation Services Catalog adds governance to Job Templates and Workflows"
 home-page = https://github.com/ansible/pinakes
 description-file = README.md
-license_file = LICENSE.md
+license_file = LICENSE
 
 [files]
 packages =


### PR DESCRIPTION
The wrong filename can prevent the dist pkg build. 

please @eclarizio review. 